### PR TITLE
Add Vercel configuration

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,0 +1,5 @@
+const { server } = require('../server/index.js');
+
+module.exports = (req, res) => {
+  server.emit('request', req, res);
+};

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "scripts": {
     "start": "node server/index.js",
-    "heroku-postbuild": "cd frontend && npm install && npm run build"
+    "heroku-postbuild": "cd frontend && npm install && npm run build",
+    "vercel-build": "cd frontend && npm install && npm run build"
   },
   "engines": {
     "node": "18.x"

--- a/server/index.js
+++ b/server/index.js
@@ -2664,8 +2664,12 @@ function shuffleArray(array) {
   return array;
 }
 
-// Start the server
+// Start the server only when this file is run directly
 const PORT = process.env.PORT || 3001;
-server.listen(PORT, () => {
-  console.log(`Server running on port ${PORT}`);
-}); // Start the server
+if (require.main === module) {
+  server.listen(PORT, () => {
+    console.log(`Server running on port ${PORT}`);
+  });
+}
+
+module.exports = { app, server };

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,17 @@
+{
+  "builds": [
+    { "src": "api/index.js", "use": "@vercel/node" },
+    {
+      "src": "frontend/package.json",
+      "use": "@vercel/static-build",
+      "config": { "distDir": "frontend/build" }
+    }
+  ],
+  "functions": {
+    "api/index.js": { "runtime": "nodejs18.x" }
+  },
+  "routes": [
+    { "src": "/api/(.*)", "dest": "api/index.js" },
+    { "src": "/(.*)", "dest": "frontend/build/$1" }
+  ]
+}


### PR DESCRIPTION
## Summary
- make server export Express app and only listen when run locally
- route API requests through new `api` serverless function
- add `vercel-build` script and project `vercel.json`
- specify Node 18 runtime for the API function

## Testing
- `npm test` *(fails: Missing script)*
- `npm run vercel-build` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6883a0730dd4832c86008a10efbc042a