### PR TITLE
Remove functions from vercel config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -7,9 +7,6 @@
       "config": { "distDir": "frontend/build" }
     }
   ],
-  "functions": {
-    "api/index.js": { "runtime": "nodejs18.x" }
-  },
   "routes": [
     { "src": "/api/(.*)", "dest": "api/index.js" },
     { "src": "/(.*)", "dest": "frontend/build/$1" }


### PR DESCRIPTION
## Summary
- remove `functions` entry from `vercel.json` so that only `builds` is used

## Testing
- `npm test` *(fails: react-scripts not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6883b27635b8832cb7c9f1f93cc011ed