### PR TITLE
Fix Node version for Vercel build

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,6 +47,6 @@
   },
   "proxy": "http://localhost:3001",
   "engines": {
-    "node": "22.x"
+    "node": "18.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "vercel-build": "cd frontend && npm install && npm run build"
   },
   "engines": {
-    "node": "22.x"
+    "node": "18.x"
   },
   "devDependencies": {
     "@types/recharts": "^1.8.29"


### PR DESCRIPTION
## Summary
- set Node engine to 18.x so the build works on Vercel

## Testing
- `npm test --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883ba5ae794832c85776a35a8859735