### PR TITLE
Add session activity updates to more socket events

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -321,6 +321,8 @@ io.on("connection", (socket) => {
     // Generate a random 6-character session ID
     const sessionId = Math.random().toString(36).substring(2, 8).toUpperCase();
 
+    updateSessionActivity(sessionId);
+
     sessions[sessionId] = {
       host: socket.id,
       players: [{ id: socket.id, name: hostName }],
@@ -348,6 +350,8 @@ io.on("connection", (socket) => {
   // Join an existing session
   socket.on("join-session", (sessionId, playerName) => {
     const sessionIdUpper = sessionId.toUpperCase();
+
+    updateSessionActivity(sessionIdUpper);
 
     if (!sessions[sessionIdUpper]) {
       socket.emit("error", { message: "Session not found" });
@@ -1098,6 +1102,8 @@ io.on("connection", (socket) => {
   socket.on("laugh-set-duration", (sessionId, duration) => {
     const session = sessions[sessionId];
 
+    updateSessionActivity(sessionId);
+
     if (!session || session.gameType !== GAME_TYPES.NOT_ALLOWED_TO_LAUGH) {
       socket.emit("error", { message: "Invalid session or game type" });
       return;
@@ -1125,6 +1131,8 @@ io.on("connection", (socket) => {
   // Start the game (host only)
   socket.on("laugh-start-game", (sessionId, duration) => {
     const session = sessions[sessionId];
+
+    updateSessionActivity(sessionId);
 
     if (!session || session.gameType !== GAME_TYPES.NOT_ALLOWED_TO_LAUGH) {
       socket.emit("error", { message: "Invalid session or game type" });
@@ -1212,6 +1220,8 @@ io.on("connection", (socket) => {
   socket.on("laugh-submit-response", (sessionId, response) => {
     const session = sessions[sessionId];
 
+    updateSessionActivity(sessionId);
+
     if (!session || session.gameType !== GAME_TYPES.NOT_ALLOWED_TO_LAUGH) {
       socket.emit("error", { message: "Invalid session or game type" });
       return;
@@ -1246,6 +1256,8 @@ io.on("connection", (socket) => {
   // Show next response (host only)
   socket.on("laugh-next-response", (sessionId) => {
     const session = sessions[sessionId];
+
+    updateSessionActivity(sessionId);
 
     if (!session || session.gameType !== GAME_TYPES.NOT_ALLOWED_TO_LAUGH) {
       socket.emit("error", { message: "Invalid session or game type" });
@@ -1284,6 +1296,8 @@ io.on("connection", (socket) => {
   // Restart game (host only)
   socket.on("laugh-restart-game", (sessionId) => {
     const session = sessions[sessionId];
+
+    updateSessionActivity(sessionId);
 
     if (!session || session.gameType !== GAME_TYPES.NOT_ALLOWED_TO_LAUGH) {
       socket.emit("error", { message: "Invalid session or game type" });
@@ -1331,6 +1345,8 @@ io.on("connection", (socket) => {
 
   socket.on("drink-or-judge-next-statement", (sessionId) => {
     const session = sessions[sessionId];
+
+    updateSessionActivity(sessionId);
 
     if (!session || session.gameType !== GAME_TYPES.DRINK_OR_JUDGE) {
       socket.emit("error", { message: "Invalid session or game type" });
@@ -1454,6 +1470,8 @@ io.on("connection", (socket) => {
   socket.on("music-guess-submit-song", (sessionId, song) => {
     const session = sessions[sessionId];
 
+    updateSessionActivity(sessionId);
+
     if (!session || session.gameType !== GAME_TYPES.MUSIC_GUESS) {
       socket.emit("error", { message: "Invalid session or game type" });
       return;
@@ -1511,6 +1529,8 @@ io.on("connection", (socket) => {
 
   socket.on("music-guess-start-guessing", (sessionId) => {
     const session = sessions[sessionId];
+
+    updateSessionActivity(sessionId);
 
     if (!session || session.gameType !== GAME_TYPES.MUSIC_GUESS) {
       socket.emit("error", { message: "Invalid session or game type" });
@@ -1575,6 +1595,8 @@ io.on("connection", (socket) => {
   socket.on("music-guess-vote", (sessionId, votedForId) => {
     const session = sessions[sessionId];
 
+    updateSessionActivity(sessionId);
+
     if (!session || session.gameType !== GAME_TYPES.MUSIC_GUESS) {
       socket.emit("error", { message: "Invalid session or game type" });
       return;
@@ -1620,6 +1642,8 @@ io.on("connection", (socket) => {
   socket.on("music-guess-force-results", (sessionId) => {
     const session = sessions[sessionId];
 
+    updateSessionActivity(sessionId);
+
     if (!session || session.gameType !== GAME_TYPES.MUSIC_GUESS) {
       socket.emit("error", { message: "Invalid session or game type" });
       return;
@@ -1637,6 +1661,8 @@ io.on("connection", (socket) => {
   // Music Guess - Next song
   socket.on("music-guess-next-song", (sessionId) => {
     const session = sessions[sessionId];
+
+    updateSessionActivity(sessionId);
 
     if (!session || session.gameType !== GAME_TYPES.MUSIC_GUESS) {
       socket.emit("error", { message: "Invalid session or game type" });
@@ -1883,6 +1909,8 @@ io.on("connection", (socket) => {
   socket.on("start-never-timer", (sessionId, duration) => {
     const session = sessions[sessionId];
 
+    updateSessionActivity(sessionId);
+
     if (!session || session.gameType !== GAME_TYPES.NEVER_HAVE_I_EVER) {
       socket.emit("error", { message: "Invalid session or game type" });
       return;
@@ -1975,6 +2003,8 @@ io.on("connection", (socket) => {
   socket.on("submit-response", (sessionId, response) => {
     const session = sessions[sessionId];
 
+    updateSessionActivity(sessionId);
+
     if (!session || session.gameType !== GAME_TYPES.NEVER_HAVE_I_EVER) {
       socket.emit("error", { message: "Invalid session or game type" });
       return;
@@ -2019,6 +2049,8 @@ io.on("connection", (socket) => {
   // Never Have I Ever - Next statement (host can force next)
   socket.on("next-statement", (sessionId) => {
     const session = sessions[sessionId];
+
+    updateSessionActivity(sessionId);
 
     if (!session || session.gameType !== GAME_TYPES.NEVER_HAVE_I_EVER) {
       socket.emit("error", { message: "Invalid session or game type" });


### PR DESCRIPTION
## Summary
- call `updateSessionActivity` in multiple socket handlers
- record activity when sessions are created, joined, timers triggered and responses submitted

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6883e0de0e50832cb182d1d95debae3f