### PR TITLE
Align Node version in lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@types/recharts": "^1.8.29"
       },
       "engines": {
-        "node": "18.x"
+        "node": "22.x"
       }
     },
     "node_modules/@babel/runtime": {


### PR DESCRIPTION
## Summary
- update package-lock.json to require Node.js 22.x

## Testing
- `npm ci --offline` *(fails: cache not available)*

------
https://chatgpt.com/codex/tasks/task_e_6883e0da73d4832c9b49e77b93513d5b