### PR TITLE
Fix wheel visibility and speed

### DIFF
--- a/frontend/src/styles/Skjenkehjulet.css
+++ b/frontend/src/styles/Skjenkehjulet.css
@@ -181,6 +181,21 @@
   gap: 32px;
 }
 
+.wheel-container {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.countdown-phase .countdown-display {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 2;
+}
+
 .countdown-display {
   background: linear-gradient(135deg, #1e3c72, #2a5298);
   padding: 40px;


### PR DESCRIPTION
## Summary
- display wheel during countdown
- overlay countdown on top of wheel
- allow drawing of wheel without spinning
- slow down wheel spin

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68842793e088832c88cf61e50929c903