### PR TITLE
Add Skjenkehjulet gamemode

### DIFF
--- a/frontend/src/components/Game.tsx
+++ b/frontend/src/components/Game.tsx
@@ -10,6 +10,7 @@ import DrinkOrJudge from "./DrinkOrJudge";
 import Beat4Beat from "./Beat4Beat";
 import LamboScreen from "./LamboScreen"; // Import the new LamboScreen component
 import NotAllowedToLaugh from "./NotAllowedToLaugh";
+import Skjenkehjulet from "./Skjenkehjulet";
 
 // Game type constants (must match server constants)
 const GAME_TYPES = {
@@ -18,7 +19,8 @@ const GAME_TYPES = {
   MUSIC_GUESS: "musicGuess",
   DRINK_OR_JUDGE: "drinkOrJudge",
   BEAT4BEAT: "beat4Beat",
-  NOT_ALLOWED_TO_LAUGH: "notAllowedToLaugh", // Added new game type
+  NOT_ALLOWED_TO_LAUGH: "notAllowedToLaugh",
+  SKJENKEHJULET: "skjenkehjulet",
 };
 
 const Game: React.FC = () => {
@@ -376,6 +378,19 @@ const Game: React.FC = () => {
       case GAME_TYPES.BEAT4BEAT:
         return (
           <Beat4Beat
+            sessionId={sessionData.sessionId}
+            players={sessionData.players}
+            isHost={sessionData.isHost}
+            gameState={sessionData.gameState}
+            socket={socket}
+            restartGame={restartGame}
+            leaveSession={confirmLeaveSession}
+            returnToLobby={returnToLobby}
+          />
+        );
+      case GAME_TYPES.SKJENKEHJULET:
+        return (
+          <Skjenkehjulet
             sessionId={sessionData.sessionId}
             players={sessionData.players}
             isHost={sessionData.isHost}

--- a/frontend/src/components/GameLobby.tsx
+++ b/frontend/src/components/GameLobby.tsx
@@ -95,6 +95,12 @@ const GameLobby: React.FC<GameLobbyProps> = ({
     },
     { id: "beat4Beat", name: "Beat4Beat", icon: "🎧", color: "#e53935" },
     {
+      id: "skjenkehjulet",
+      name: "Skjenkehjulet",
+      icon: "🎡",
+      color: "#ff9800",
+    },
+    {
       id: "notAllowedToLaugh",
       name: "Ikke lov å le på vors",
       icon: "😂",

--- a/frontend/src/components/Skjenkehjulet.tsx
+++ b/frontend/src/components/Skjenkehjulet.tsx
@@ -1,0 +1,37 @@
+import React, { useState } from "react";
+import { CustomSocket } from "../types/socket.types";
+import "../styles/Skjenkehjulet.css";
+
+interface SkjenkehjuletProps {
+  sessionId: string;
+  players: any[];
+  isHost: boolean;
+  gameState: any;
+  socket: CustomSocket | null;
+  restartGame: () => void;
+  leaveSession: () => void;
+  returnToLobby: () => void;
+}
+
+const Skjenkehjulet: React.FC<SkjenkehjuletProps> = () => {
+  const [rotation, setRotation] = useState(0);
+
+  const spinWheel = () => {
+    const extra = 360 * 3 + Math.floor(Math.random() * 360);
+    setRotation((prev) => prev + extra);
+  };
+
+  return (
+    <div className="skjenkehjulet">
+      <h2>Skjenkehjulet</h2>
+      <div className="wheel-container">
+        <div className="wheel" style={{ transform: `rotate(${rotation}deg)` }} />
+      </div>
+      <button className="spin-button" onClick={spinWheel}>
+        Test Plinko Wheel
+      </button>
+    </div>
+  );
+};
+
+export default Skjenkehjulet;

--- a/frontend/src/styles/Skjenkehjulet.css
+++ b/frontend/src/styles/Skjenkehjulet.css
@@ -1,0 +1,36 @@
+.skjenkehjulet {
+  padding: 20px;
+  text-align: center;
+  color: white;
+}
+
+.wheel-container {
+  margin: 20px auto;
+  width: 200px;
+  height: 200px;
+  border: 8px solid #fff;
+  border-radius: 50%;
+  overflow: hidden;
+}
+
+.wheel {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  background: conic-gradient(
+    #f64e8b 0deg 45deg,
+    #d3ee98 45deg 90deg,
+    #f64e8b 90deg 135deg,
+    #d3ee98 135deg 180deg,
+    #f64e8b 180deg 225deg,
+    #d3ee98 225deg 270deg,
+    #f64e8b 270deg 315deg,
+    #d3ee98 315deg 360deg
+  );
+  transition: transform 4s cubic-bezier(0.33, 1, 0.68, 1);
+}
+
+.spin-button {
+  margin-top: 20px;
+  padding: 10px 20px;
+}

--- a/server/index.js
+++ b/server/index.js
@@ -167,7 +167,8 @@ const GAME_TYPES = {
   MUSIC_GUESS: "musicGuess",
   DRINK_OR_JUDGE: "drinkOrJudge", // Added new game type
   BEAT4BEAT: "beat4Beat", // Add this line
-  NOT_ALLOWED_TO_LAUGH: "notAllowedToLaugh", // Added new game type
+  NOT_ALLOWED_TO_LAUGH: "notAllowedToLaugh",
+  SKJENKEHJULET: "skjenkehjulet",
 };
 
 // Predefinerte "Jeg har aldri" setninger som brukes når brukerne går tom for egne
@@ -983,6 +984,8 @@ io.on("connection", (socket) => {
         timerDuration: 60,
         timeRemaining: 60,
       };
+    } else if (gameType === GAME_TYPES.SKJENKEHJULET) {
+      session.gameState = {};
     }
 
     // Notify all players about the game selection
@@ -2043,6 +2046,8 @@ io.on("connection", (socket) => {
           results: [],
           usedStatements: [],
         };
+      } else if (session.gameType === GAME_TYPES.SKJENKEHJULET) {
+        session.gameState = {};
       }
 
       // Notify all players the game has been restarted


### PR DESCRIPTION
## Summary
- add new `Skjenkehjulet` component with spinning wheel
- expose new gamemode in GameLobby
- handle new game type in Game component
- support new game type server side

## Testing
- `npm install --prefix frontend` *(fails: internet access blocked)*
- `npm test --prefix frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884b6b71278832ca5bcc8d074f1d32a