### PR TITLE
Add Skjenkehjulet gamemode

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "react-router-dom": "^7.3.0",
     "react-scripts": "5.0.1",
     "socket.io-client": "^4.8.1",
+    "matter-js": "^0.19.0",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"
   },

--- a/frontend/src/components/Game.tsx
+++ b/frontend/src/components/Game.tsx
@@ -10,6 +10,7 @@ import DrinkOrJudge from "./DrinkOrJudge";
 import Beat4Beat from "./Beat4Beat";
 import LamboScreen from "./LamboScreen"; // Import the new LamboScreen component
 import NotAllowedToLaugh from "./NotAllowedToLaugh";
+import Skjenkehjulet from "./Skjenkehjulet";
 
 // Game type constants (must match server constants)
 const GAME_TYPES = {
@@ -19,6 +20,7 @@ const GAME_TYPES = {
   DRINK_OR_JUDGE: "drinkOrJudge",
   BEAT4BEAT: "beat4Beat",
   NOT_ALLOWED_TO_LAUGH: "notAllowedToLaugh", // Added new game type
+  SKJENKEHJULET: "skjenkehjulet",
 };
 
 const Game: React.FC = () => {
@@ -398,6 +400,10 @@ const Game: React.FC = () => {
             leaveSession={confirmLeaveSession}
             returnToLobby={returnToLobby}
           />
+        );
+      case GAME_TYPES.SKJENKEHJULET:
+        return (
+          <Skjenkehjulet />
         );
       case GAME_TYPES.NONE:
       default:

--- a/frontend/src/components/GameLobby.tsx
+++ b/frontend/src/components/GameLobby.tsx
@@ -100,6 +100,12 @@ const GameLobby: React.FC<GameLobbyProps> = ({
       icon: "😂",
       color: "#6200ea",
     },
+    {
+      id: "skjenkehjulet",
+      name: "Skjenkehjulet",
+      icon: "🍻",
+      color: "#0a7c40",
+    },
   ];
 
   // Find the host's name for the waiting message

--- a/frontend/src/components/Skjenkehjulet.tsx
+++ b/frontend/src/components/Skjenkehjulet.tsx
@@ -1,0 +1,102 @@
+import React, { useEffect } from "react";
+import "../styles/Skjenkehjulet.css";
+import Matter from "matter-js";
+
+const Skjenkehjulet: React.FC = () => {
+  useEffect(() => {
+    const { Engine, Events, Runner, Bodies, Constraint } = Matter as any;
+    const svg = document.querySelector("#skjenk-svg") as SVGSVGElement;
+    if (!svg) return;
+    const viewboxArray = svg.getAttribute("viewBox")!.split(" ");
+    const vbWidth = parseInt(viewboxArray[2]);
+    const vbHeight = parseInt(viewboxArray[3]);
+
+    const engine = Engine.create();
+    const runner = Runner.create();
+
+    const ballGraphic = document.getElementById("skjenk-ball") as SVGCircleElement;
+    let ballBody: Matter.Body;
+    const anchorGraphic = document.getElementById("skjenk-anchor") as SVGCircleElement;
+    let anchorBody: Matter.Body;
+    let anchorConstraint: Matter.Constraint;
+
+    const initBallBody = () => {
+      const xpos = parseInt(ballGraphic.getAttribute("cx")!);
+      const ypos = parseInt(ballGraphic.getAttribute("cy")!);
+      const r = parseInt(ballGraphic.getAttribute("r")!);
+      ballBody = Bodies.circle(0, 0, r, { friction: 0, restitution: 0.6 });
+      Matter.Body.setPosition(ballBody, { x: xpos, y: ypos });
+    };
+
+    const initAnchorBody = () => {
+      const xpos = parseInt(anchorGraphic.getAttribute("cx")!);
+      const ypos = parseInt(anchorGraphic.getAttribute("cy")!);
+      const r = parseInt(anchorGraphic.getAttribute("r")!);
+      anchorBody = Bodies.circle(0, 0, r, { isStatic: true });
+      Matter.Body.setPosition(anchorBody, { x: xpos, y: ypos });
+    };
+
+    const initConstraint = () => {
+      anchorConstraint = Constraint.create({
+        bodyA: anchorBody,
+        bodyB: ballBody,
+        stiffness: 0.1,
+        length: 75,
+      });
+    };
+
+    const initFloor = () => {
+      const floor = Bodies.rectangle(vbWidth / 2, vbHeight + 25, vbWidth, 50, { isStatic: true });
+      Matter.Composite.add(engine.world, floor);
+    };
+
+    const dropButton = document.getElementById("skjenk-drop") as HTMLButtonElement;
+    const dropBall = () => {
+      Matter.Composite.remove(engine.world, anchorConstraint);
+    };
+
+    dropButton.addEventListener("click", dropBall);
+
+    initBallBody();
+    initAnchorBody();
+    initConstraint();
+    initFloor();
+    Matter.Composite.add(engine.world, [ballBody, anchorBody, anchorConstraint]);
+    Runner.run(runner, engine);
+
+    Events.on(engine, "afterUpdate", () => {
+      const pos = ballBody.position;
+      ballGraphic.setAttribute("cx", pos.x.toString());
+      ballGraphic.setAttribute("cy", pos.y.toString());
+      if (anchorConstraint) {
+        const chain = document.getElementById("skjenk-chain") as SVGPathElement;
+        chain.setAttribute("d", `M${pos.x},${pos.y} L${anchorBody.position.x},${anchorBody.position.y}`);
+      }
+    });
+
+    return () => {
+      dropButton.removeEventListener("click", dropBall);
+      Matter.Render.stop(engine);
+      Runner.stop(runner);
+    };
+  }, []);
+
+  return (
+    <div className="skjenkehjulet-container">
+      <svg id="skjenk-svg" width="600" height="600" viewBox="0 0 1000 1000" fill="none">
+        <defs>
+          <radialGradient id="ball_gradient" cx="20%" cy="20%" fx="20%" fy="20%">
+            <stop offset="0%" stopColor="#FF7373" />
+            <stop offset="100%" stopColor="#790202" />
+          </radialGradient>
+        </defs>
+        <circle id="skjenk-ball" cx="500" cy="50" r="20" fill="url(#ball_gradient)" />
+        <circle id="skjenk-anchor" cx="500" cy="10" r="7" fill="white" stroke="black" />
+        <path id="skjenk-chain" d="" stroke="white" strokeWidth="3" />
+      </svg>
+      <button id="skjenk-drop">Test Plinko</button>
+    </div>
+  );
+};
+
+export default Skjenkehjulet;

--- a/frontend/src/styles/Skjenkehjulet.css
+++ b/frontend/src/styles/Skjenkehjulet.css
@@ -1,0 +1,10 @@
+.skjenkehjulet-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+}
+
+#skjenk-drop {
+  margin-top: 10px;
+}

--- a/server/index.js
+++ b/server/index.js
@@ -168,6 +168,7 @@ const GAME_TYPES = {
   DRINK_OR_JUDGE: "drinkOrJudge", // Added new game type
   BEAT4BEAT: "beat4Beat", // Add this line
   NOT_ALLOWED_TO_LAUGH: "notAllowedToLaugh", // Added new game type
+  SKJENKEHJULET: "skjenkehjulet",
 };
 
 // Predefinerte "Jeg har aldri" setninger som brukes når brukerne går tom for egne


### PR DESCRIPTION
## Summary
- add new frontend game mode component `Skjenkehjulet` implementing a small plinko style demo using matter‑js
- register game type in lobby and game switch logic
- expose new `SKJENKEHJULET` constant on server for validation
- basic style for new component
- include matter-js dependency

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884b89af018832cbdceea277f10a927