### PR TITLE
Update Skjenkehjulet UI flow

### DIFF
--- a/frontend/src/components/Game.tsx
+++ b/frontend/src/components/Game.tsx
@@ -10,7 +10,7 @@ import DrinkOrJudge from "./DrinkOrJudge";
 import Beat4Beat from "./Beat4Beat";
 import LamboScreen from "./LamboScreen"; // Import the new LamboScreen component
 import NotAllowedToLaugh from "./NotAllowedToLaugh";
-import Skjenkehjulet from "./Skjenkehjulet";
+import Skjenkehjulet, { SkjenkehjuletHandle } from "./Skjenkehjulet";
 
 // Game type constants (must match server constants)
 const GAME_TYPES = {
@@ -50,6 +50,7 @@ const Game: React.FC = () => {
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
   // Flag to track if we've successfully joined a session
   const hasJoinedRef = useRef(false);
+  const skjRef = useRef<SkjenkehjuletHandle>(null);
 
   useEffect(() => {
     if (!socket) {
@@ -390,7 +391,7 @@ const Game: React.FC = () => {
         );
       case GAME_TYPES.SKJENKEHJULET:
         return (
-          <Skjenkehjulet />
+          <Skjenkehjulet ref={skjRef} />
         );
       case GAME_TYPES.NOT_ALLOWED_TO_LAUGH:
         return (
@@ -455,6 +456,8 @@ const Game: React.FC = () => {
           socket={socket}
           sessionId={sessionData.sessionId}
           lamboVotes={lamboVotes}
+          showBackArrow={sessionData.gameType === GAME_TYPES.SKJENKEHJULET}
+          onBackArrowClick={sessionData.gameType === GAME_TYPES.SKJENKEHJULET ? () => skjRef.current?.goToConfig() : undefined}
         />
       )}
 
@@ -479,7 +482,10 @@ const Game: React.FC = () => {
         )}
 
         {/* Lambo button - now with a proper container */}
-        {!isReconnecting && !error && sessionData.sessionId && (
+        {!isReconnecting &&
+          !error &&
+          sessionData.sessionId &&
+          sessionData.gameType !== GAME_TYPES.SKJENKEHJULET && (
           <div className="lambo-button-container">
             <button
               onClick={handleLamboVote}
@@ -499,15 +505,17 @@ const Game: React.FC = () => {
         )}
 
         {/* Leave Session button */}
-        <div className="mobile-leave-button-container">
-          <button
-            onClick={confirmLeaveSession}
-            className="mobile-leave-button"
-            aria-label="Leave Session"
-          >
-            Leave Session
-          </button>
-        </div>
+        {sessionData.gameType !== GAME_TYPES.SKJENKEHJULET && (
+          <div className="mobile-leave-button-container">
+            <button
+              onClick={confirmLeaveSession}
+              className="mobile-leave-button"
+              aria-label="Leave Session"
+            >
+              Leave Session
+            </button>
+          </div>
+        )}
       </div>
 
       {/* Leave confirmation dialog */}

--- a/frontend/src/components/ParticipantPanel.tsx
+++ b/frontend/src/components/ParticipantPanel.tsx
@@ -9,6 +9,8 @@ interface ParticipantPanelProps {
   socket: CustomSocket | null;
   sessionId: string;
   lamboVotes: string[]; // Added prop for lambo votes
+  showBackArrow?: boolean;
+  onBackArrowClick?: () => void;
 }
 
 const ParticipantPanel: React.FC<ParticipantPanelProps> = ({
@@ -18,6 +20,8 @@ const ParticipantPanel: React.FC<ParticipantPanelProps> = ({
   socket,
   sessionId,
   lamboVotes,
+  showBackArrow = false,
+  onBackArrowClick,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const panelRef = useRef<HTMLDivElement>(null);
@@ -68,13 +72,23 @@ const ParticipantPanel: React.FC<ParticipantPanelProps> = ({
     <>
       {/* Only show toggle button when panel is closed */}
       {!isOpen && (
-        <button
-          className={`participant-toggle ${isHost ? "is-host" : ""}`}
-          onClick={togglePanel}
-          aria-label="Vis deltakere"
-        >
-          👥
-        </button>
+        showBackArrow && isHost ? (
+          <button
+            className="back-arrow"
+            onClick={onBackArrowClick}
+            aria-label="Tilbake"
+          >
+            ←
+          </button>
+        ) : (
+          <button
+            className={`participant-toggle ${isHost ? "is-host" : ""}`}
+            onClick={togglePanel}
+            aria-label="Vis deltakere"
+          >
+            👥
+          </button>
+        )
       )}
 
       {/* Overlay shown when panel is open */}

--- a/frontend/src/components/Skjenkehjulet.tsx
+++ b/frontend/src/components/Skjenkehjulet.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState, forwardRef, useImperativeHandle } from "react";
 import "../styles/Skjenkehjulet.css";
 
 const matterUrl =
@@ -10,7 +10,14 @@ declare global {
   }
 }
 
-const Skjenkehjulet: React.FC = () => {
+export interface SkjenkehjuletHandle {
+  goToConfig: () => void;
+}
+
+const Skjenkehjulet: React.ForwardRefRenderFunction<SkjenkehjuletHandle> = (
+  _,
+  ref
+) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [ready, setReady] = useState(false);
   const [phase, setPhase] = useState<
@@ -27,6 +34,10 @@ const Skjenkehjulet: React.FC = () => {
   const boardFuncs = useRef<{ drop: () => void; reset: () => void } | null>(
     null
   );
+
+  useImperativeHandle(ref, () => ({
+    goToConfig: () => setPhase("config"),
+  }));
 
   // Load Matter.js dynamically when component mounts
   useEffect(() => {
@@ -660,4 +671,4 @@ const Skjenkehjulet: React.FC = () => {
   );
 };
 
-export default Skjenkehjulet;
+export default forwardRef(Skjenkehjulet);

--- a/frontend/src/styles/ParticipantPanel.css
+++ b/frontend/src/styles/ParticipantPanel.css
@@ -35,6 +35,38 @@
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
 }
 
+/* Back arrow shown in Skjenkehjulet */
+.back-arrow {
+  position: fixed;
+  top: 16px;
+  left: 16px;
+  z-index: 100;
+  background-color: rgba(124, 77, 255, 0.2);
+  color: white;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  border: none;
+  cursor: pointer;
+  font-size: 24px;
+  transition: all 0.2s ease;
+}
+
+.back-arrow:hover {
+  background-color: rgba(124, 77, 255, 0.4);
+  transform: scale(1.05);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.3);
+}
+
+.back-arrow:active {
+  transform: scale(0.95);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+}
+
 .participant-panel {
   position: fixed;
   top: 0;


### PR DESCRIPTION
## Summary
- add optional back arrow handling to `ParticipantPanel`
- hide lambo and leave buttons in Skjenkehjulet
- expose a `goToConfig` ref on `Skjenkehjulet`
- style back arrow similar to participant toggle

## Testing
- `npm test --prefix frontend` *(fails: react-scripts not found)*
- `npm run build --prefix frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884c7b60538832c8e521ab4cbc799a1