### PR TITLE
Add slot reveal and spinning wheel

### DIFF
--- a/frontend/src/components/SpinWheel.tsx
+++ b/frontend/src/components/SpinWheel.tsx
@@ -1,0 +1,66 @@
+import React, { useEffect, useRef } from "react";
+import "../styles/SpinWheel.css";
+
+interface SpinWheelProps {
+  categories: string[];
+  onFinish: (category: string) => void;
+}
+
+const SpinWheel: React.FC<SpinWheelProps> = ({ categories, onFinish }) => {
+  const wheelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const wheel = wheelRef.current;
+    if (!wheel) return;
+
+    const segAngle = 360 / categories.length;
+    const index = Math.floor(Math.random() * categories.length);
+    const finalRotation = 1080 + index * segAngle + segAngle / 2;
+    wheel.style.transition = "transform 5s cubic-bezier(0.33,1,0.68,1)";
+    wheel.style.transform = `rotate(-${finalRotation}deg)`;
+
+    const timer = setTimeout(() => {
+      onFinish(categories[index]);
+    }, 5200);
+    return () => clearTimeout(timer);
+  }, [categories, onFinish]);
+
+  return (
+    <div className="wheel-wrapper">
+      <div className="wheel" ref={wheelRef}>
+        <svg viewBox="0 0 730 730">
+          <g className="wheel-group">
+            <circle className="frame" cx="365" cy="365" r="347.6" />
+            <g className="sectors">
+              {categories.map((_, i) => (
+                <path
+                  key={i}
+                  d={`M365,365 L365,35 A328,328 0 0,1 ${365 +
+                    328 * Math.cos((2 * Math.PI * (i + 1)) / categories.length)},${365 +
+                    328 * Math.sin((2 * Math.PI * (i + 1)) / categories.length)} Z`}
+                  className={`sector sector-${i}`}
+                />
+              ))}
+            </g>
+          </g>
+        </svg>
+        {categories.map((c, i) => (
+          <div
+            key={c}
+            className="label"
+            style={{
+              transform: `rotate(${(360 / categories.length) * i}deg) translateY(-160px) rotate(-${
+                (360 / categories.length) * i
+              }deg)`
+            }}
+          >
+            {c}
+          </div>
+        ))}
+      </div>
+      <div className="pointer" />
+    </div>
+  );
+};
+
+export default SpinWheel;

--- a/frontend/src/styles/Skjenkehjulet.css
+++ b/frontend/src/styles/Skjenkehjulet.css
@@ -65,3 +65,39 @@
     opacity: 1;
   }
 }
+
+/* highlight and fade */
+.dim-slot {
+  opacity: 0.2;
+}
+.winning-slot {
+  opacity: 1 !important;
+  filter: drop-shadow(0 0 10px yellow);
+}
+
+.board-fade {
+  animation: boardFade 0.5s forwards;
+}
+
+@keyframes boardFade {
+  to {
+    opacity: 0;
+  }
+}
+
+.result-popup {
+  position: absolute;
+  font-size: 80px;
+  font-weight: bold;
+  color: white;
+  transform: translate(-50%, -50%) scale(0);
+  pointer-events: none;
+}
+.result-popup.show {
+  transition: transform 0.6s ease-out;
+  transform: translate(-50%, -50%) scale(3);
+}
+
+.chug-bg {
+  background-color: #570000;
+}

--- a/frontend/src/styles/SpinWheel.css
+++ b/frontend/src/styles/SpinWheel.css
@@ -1,0 +1,64 @@
+.wheel-wrapper {
+  position: relative;
+  width: 400px;
+  height: 400px;
+  margin: 40px auto;
+}
+
+.wheel {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  border-radius: 50%;
+  overflow: hidden;
+}
+
+.wheel svg {
+  width: 100%;
+  height: 100%;
+  transform-origin: 50% 50%;
+}
+
+.pointer {
+  position: absolute;
+  top: -10px;
+  left: 50%;
+  width: 0;
+  height: 0;
+  border-left: 10px solid transparent;
+  border-right: 10px solid transparent;
+  border-bottom: 20px solid #fff;
+  transform: translateX(-50%);
+}
+
+.label {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform-origin: 0 0;
+  font-size: 14px;
+  font-weight: bold;
+  pointer-events: none;
+  color: #fff;
+}
+
+.sector {
+  fill: #ba4d4e;
+}
+
+/* alternating colors */
+.sector-1,
+.sector-4,
+.sector-7 {
+  fill: #1592e8;
+}
+.sector-2,
+.sector-5,
+.sector-8 {
+  fill: #14c187;
+}
+.sector-3,
+.sector-6,
+.sector-9 {
+  fill: #fc7800;
+}


### PR DESCRIPTION
## Summary
- add spinning wheel component
- highlight Plinko slot and fade board
- move result text to center with bounce
- show wheel to select random category
- style wheel and animations

## Testing
- `npm test --prefix frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884cd21b218832cae264e8443088ca8