### PR TITLE
Add CHUG danger overlay

### DIFF
--- a/frontend/src/components/LuckyWheel.tsx
+++ b/frontend/src/components/LuckyWheel.tsx
@@ -1,0 +1,142 @@
+import React, { useEffect, useRef } from "react";
+import "../styles/LuckyWheel.css";
+
+interface LuckyWheelProps {
+  categories: string[];
+  onFinish: (cat: string) => void;
+}
+
+const LuckyWheel: React.FC<LuckyWheelProps> = ({ categories, onFinish }) => {
+  const wheelRef = useRef<SVGGElement>(null);
+
+  useEffect(() => {
+    const wheel = wheelRef.current;
+    if (!wheel) return;
+    const deg = 360 + Math.floor(Math.random() * 720);
+    wheel.style.transition = "transform 5s cubic-bezier(0.2, 0, 0.3, 1)";
+    wheel.style.transform = `rotate(${deg}deg)`;
+    const timeout = setTimeout(() => {
+      const finalDeg = ((deg % 360) + 360) % 360;
+      const slice = 360 / categories.length;
+      const index = Math.floor((categories.length - finalDeg / slice)) % categories.length;
+      onFinish(categories[index]);
+    }, 5000);
+    return () => clearTimeout(timeout);
+  }, [categories, onFinish]);
+
+  return (
+    <div className="luckywheel-container">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 730 730"
+        className="luckywheel-svg"
+      >
+        <g className="wheel" ref={wheelRef}>
+          <circle className="frame" cx="365" cy="365" r="347.6" />
+          <g className="sticks">
+            <rect x="360.4" width="9.3" height="24.33" rx="4" ry="4" />
+            <rect
+              x="352.8"
+              y="713.2"
+              width="24.3"
+              height="9.27"
+              rx="4"
+              ry="4"
+              transform="translate(1082.8 352.8) rotate(90)"
+            />
+            <rect
+              x="176.4"
+              y="54.8"
+              width="24.3"
+              height="9.27"
+              rx="4"
+              ry="4"
+              transform="translate(145.8 -133.6) rotate(60)"
+            />
+            <rect
+              x="529.2"
+              y="665.9"
+              width="24.3"
+              height="9.27"
+              rx="4"
+              ry="4"
+              transform="translate(851.4 -133.6) rotate(60)"
+            />
+            <rect
+              x="47.3"
+              y="183.9"
+              width="24.3"
+              height="9.27"
+              rx="4"
+              ry="4"
+              transform="translate(102.3 -4.5) rotate(30)"
+            />
+            <rect
+              x="658.4"
+              y="536.8"
+              width="24.3"
+              height="9.27"
+              rx="4"
+              ry="4"
+              transform="translate(360.5 -262.7) rotate(30)"
+            />
+            <rect y="360.4" width="24.3" height="9.27" rx="4" ry="4" />
+            <rect x="705.7" y="360.4" width="24.3" height="9.27" rx="4" ry="4" />
+            <rect
+              x="47.3"
+              y="536.8"
+              width="24.3"
+              height="9.27"
+              rx="4"
+              ry="4"
+              transform="translate(-262.7 102.3) rotate(-30)"
+            />
+            <rect
+              x="658.4"
+              y="183.9"
+              width="24.3"
+              height="9.27"
+              rx="4"
+              ry="4"
+              transform="translate(-4.5 360.5) rotate(-30)"
+            />
+            <rect
+              x="176.4"
+              y="665.9"
+              width="24.3"
+              height="9.27"
+              rx="4"
+              ry="4"
+              transform="translate(-486.4 498.6) rotate(-60)"
+            />
+            <rect
+              x="529.2"
+              y="54.8"
+              width="24.3"
+              height="9.27"
+              rx="4"
+              ry="4"
+              transform="translate(219.2 498.6) rotate(-60)"
+            />
+          </g>
+          <g className="sectors">
+            {categories.map((c, i) => (
+              <g key={i}>
+                <path id={`s${i}`} d="" />
+                <text className="sector-label" x="365" y="365">
+                  {c}
+                </text>
+              </g>
+            ))}
+          </g>
+          <g className="middle">
+            <circle cx="365" cy="365" r="54.5" fill="#fff" />
+            <circle cx="365" cy="365" r="11.6" fill="#ccc" />
+          </g>
+        </g>
+      </svg>
+    </div>
+  );
+};
+
+export default LuckyWheel;

--- a/frontend/src/components/Skjenkehjulet.tsx
+++ b/frontend/src/components/Skjenkehjulet.tsx
@@ -6,6 +6,7 @@ import React, {
   useImperativeHandle,
 } from "react";
 import "../styles/Skjenkehjulet.css";
+import LuckyWheel from "./LuckyWheel";
 
 const matterUrl =
   "https://cdnjs.cloudflare.com/ajax/libs/matter-js/0.19.0/matter.min.js";
@@ -24,18 +25,25 @@ const Skjenkehjulet = forwardRef<SkjenkehjuletHandle>((props, ref) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [ready, setReady] = useState(false);
   const [phase, setPhase] = useState<
-    "config" | "countdown" | "playing" | "result"
+    "config" | "countdown" | "playing" | "result" | "wheel"
   >("config");
   const [countdownValue, setCountdownValue] = useState(3);
   const [rounds, setRounds] = useState(1);
   const [currentRound, setCurrentRound] = useState(1);
   const [displayCount, setDisplayCount] = useState(3);
   const [finalScore, setFinalScore] = useState<string | null>(null);
+  const [selectedSensor, setSelectedSensor] = useState<string | null>(null);
+  const [wheelCategory, setWheelCategory] = useState<string | null>(null);
   const [intensity, setIntensity] = useState(
     "Mild" as "Mild" | "Medium" | "Fyllehund" | "Grøfta"
   );
+  const [danger, setDanger] = useState(false);
   const boardFuncs = useRef<{ drop: () => void; reset: () => void } | null>(
     null
+  );
+
+  const overlay = (
+    <div className={`danger-overlay ${danger ? "active" : ""}`}></div>
   );
 
   const backToConfig = () => {
@@ -90,6 +98,43 @@ const Skjenkehjulet = forwardRef<SkjenkehjuletHandle>((props, ref) => {
       boardFuncs.current.drop();
     }
   }, [phase, ready]);
+
+  // Highlight sensor and fade board when result is ready
+  useEffect(() => {
+    if (phase !== "result") return;
+    const holder = containerRef.current;
+    if (!holder) return;
+    const rects = holder.querySelectorAll<SVGRectElement>("#sensors rect");
+    rects.forEach((r) => {
+      const key = r.getAttribute("x") + "_" + r.getAttribute("y");
+      if (key === selectedSensor) {
+        r.classList.add("highlight");
+      } else {
+        r.classList.add("dim");
+      }
+    });
+    const svg = holder.querySelector("svg");
+    svg?.classList.add("fadeout");
+    const toWheel = setTimeout(() => setPhase("wheel"), 1500);
+    return () => clearTimeout(toWheel);
+  }, [phase, selectedSensor]);
+
+  useEffect(() => {
+    if (phase !== "result") {
+      setDanger(false);
+    }
+  }, [phase]);
+
+  useEffect(() => {
+    if (phase !== "playing" && phase !== "result") {
+      const holder = containerRef.current;
+      if (!holder) return;
+      holder.querySelectorAll("#sensors rect").forEach((r) => {
+        r.classList.remove("highlight", "dim");
+      });
+      holder.querySelector("svg")?.classList.remove("fadeout");
+    }
+  }, [phase]);
 
   // Initialize plinko board when ready
   const initBoard = () => {
@@ -444,9 +489,14 @@ const Skjenkehjulet = forwardRef<SkjenkehjuletHandle>((props, ref) => {
             let id = pair.bodyA.id.includes("sensor")
               ? pair.bodyA.id
               : pair.bodyB.id;
-            const score = id.substr(7).split("_")[2];
+            const parts = id.substr(7).split("_");
+            const score = parts[2];
             scoreText.textContent = `~ ${score} ~`;
+            setSelectedSensor(`${parts[0]}_${parts[1]}`);
             setFinalScore(score);
+            if (score === "CHUG") {
+              setDanger(true);
+            }
             setPhase("result");
           }
         }
@@ -595,6 +645,7 @@ const Skjenkehjulet = forwardRef<SkjenkehjuletHandle>((props, ref) => {
   if (phase === "config") {
     return (
       <div className="skjenkehjulet config-form">
+        {overlay}
         <h2>Skjenkehjulet</h2>
         <label>
           Nedtelling (sekunder):
@@ -635,6 +686,7 @@ const Skjenkehjulet = forwardRef<SkjenkehjuletHandle>((props, ref) => {
   if (phase === "countdown") {
     return (
       <div className="skjenkehjulet">
+        {overlay}
         <div className="countdown-display">{displayCount}</div>
       </div>
     );
@@ -643,13 +695,52 @@ const Skjenkehjulet = forwardRef<SkjenkehjuletHandle>((props, ref) => {
   if (phase === "playing") {
     return (
       <div className="skjenkehjulet">
+        {overlay}
         <div ref={containerRef}></div>
+      </div>
+    );
+  }
+
+  if (phase === "result") {
+    return (
+      <div className="skjenkehjulet">
+        {overlay}
+        <div ref={containerRef}></div>
+        {finalScore && <div className="result-display">{finalScore}</div>}
+      </div>
+    );
+  }
+
+  if (phase === "wheel") {
+    return (
+      <div className="skjenkehjulet">
+        {overlay}
+        {wheelCategory ? (
+          <div className="result-display">{wheelCategory}</div>
+        ) : (
+          <LuckyWheel
+            categories={[
+              "White socks",
+              "Longest hair",
+              "Glasses",
+              "Tallest",
+              "Red shirt",
+              "Oldest",
+              "Youngest",
+              "Brown shoes",
+              "Earrings",
+              "Blue eyes",
+            ]}
+            onFinish={(c) => setWheelCategory(c)}
+          />
+        )}
       </div>
     );
   }
 
   return (
     <div className="skjenkehjulet">
+      {overlay}
       <div ref={containerRef}></div>
       {finalScore && <div className="result-display">{finalScore}</div>}
       {currentRound < rounds ? (

--- a/frontend/src/styles/LuckyWheel.css
+++ b/frontend/src/styles/LuckyWheel.css
@@ -1,0 +1,19 @@
+.luckywheel-container {
+  margin: 40px auto;
+  width: 80%;
+  text-align: center;
+}
+
+.luckywheel-svg {
+  width: 100%;
+  max-width: 500px;
+}
+
+.sector-label {
+  font-family: "Raleway", sans-serif;
+  font-size: 20px;
+  text-anchor: middle;
+  dominant-baseline: middle;
+  fill: #fff;
+}
+.wheel { transform-origin: 50% 50%; }

--- a/frontend/src/styles/Skjenkehjulet.css
+++ b/frontend/src/styles/Skjenkehjulet.css
@@ -65,3 +65,39 @@
     opacity: 1;
   }
 }
+
+.highlight { fill: gold !important; }
+.dim { opacity: 0.3; }
+.fadeout { opacity: 0; transition: opacity 0.5s ease; }
+
+.danger-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: rgba(220, 20, 20, 0.3);
+  z-index: 9999;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.5s ease-in-out, visibility 0.5s ease-in-out;
+  pointer-events: none;
+}
+
+.danger-overlay.active {
+  opacity: 1;
+  visibility: visible;
+  animation: dangerPulse 1.5s ease-in-out infinite alternate;
+}
+
+@keyframes dangerPulse {
+  0% {
+    background: rgba(220, 20, 20, 0.25);
+    box-shadow: inset 0 0 150px rgba(255, 0, 0, 0.4);
+  }
+  100% {
+    background: rgba(220, 20, 20, 0.4);
+    box-shadow: inset 0 0 300px rgba(255, 0, 0, 0.6);
+  }
+}
+


### PR DESCRIPTION
## Summary
- show pulsing red overlay when a CHUG slot is hit
- hide the overlay when moving to the next phase

## Testing
- `npm test --prefix frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884cd21b218832cae264e8443088ca8