### PR TITLE
Add manual player management for Split or Steal

### DIFF
--- a/frontend/src/components/Game.tsx
+++ b/frontend/src/components/Game.tsx
@@ -11,6 +11,9 @@ import Beat4Beat from "./Beat4Beat";
 import LamboScreen from "./LamboScreen"; // Import the new LamboScreen component
 import NotAllowedToLaugh from "./NotAllowedToLaugh";
 import Skjenkehjulet, { SkjenkehjuletHandle } from "./Skjenkehjulet";
+import SplitOrStealDashboard from "./SplitOrStealDashboard";
+import SplitOrStealController from "./SplitOrStealController";
+import SplitOrStealSetup from "./SplitOrStealSetup";
 
 // Game type constants (must match server constants)
 const GAME_TYPES = {
@@ -20,6 +23,7 @@ const GAME_TYPES = {
   DRINK_OR_JUDGE: "drinkOrJudge",
   BEAT4BEAT: "beat4Beat",
   NOT_ALLOWED_TO_LAUGH: "notAllowedToLaugh", // Added new game type
+  SPLIT_OR_STEAL: "splitOrSteal",
   SKJENKEHJULET: "skjenkehjulet",
 };
 
@@ -387,6 +391,31 @@ const Game: React.FC = () => {
             restartGame={restartGame}
             leaveSession={confirmLeaveSession}
             returnToLobby={returnToLobby}
+          />
+        );
+      case GAME_TYPES.SPLIT_OR_STEAL:
+        if (sessionData.isHost) {
+          if (sessionData.gameState?.phase === "setup") {
+            return (
+              <SplitOrStealSetup
+                sessionId={sessionData.sessionId}
+                socket={socket}
+              />
+            );
+          }
+          return (
+            <SplitOrStealDashboard
+              sessionId={sessionData.sessionId}
+              gameState={sessionData.gameState}
+              socket={socket}
+            />
+          );
+        }
+        return (
+          <SplitOrStealController
+            sessionId={sessionData.sessionId}
+            gameState={sessionData.gameState}
+            socket={socket}
           />
         );
       case GAME_TYPES.SKJENKEHJULET:

--- a/frontend/src/components/GameLobby.tsx
+++ b/frontend/src/components/GameLobby.tsx
@@ -100,6 +100,12 @@ const GameLobby: React.FC<GameLobbyProps> = ({
       icon: "😂",
       color: "#6200ea",
     },
+    {
+      id: "splitOrSteal",
+      name: "Split or Steal",
+      icon: "💰",
+      color: "#3f51b5",
+    },
     { id: "skjenkehjulet", name: "Skjenkehjulet", icon: "🍻", color: "#ff9800" },
   ];
 

--- a/frontend/src/components/SplitOrStealController.tsx
+++ b/frontend/src/components/SplitOrStealController.tsx
@@ -1,0 +1,166 @@
+import React, { useEffect, useState } from "react";
+import { CustomSocket } from "../types/socket.types";
+import "../styles/SplitOrSteal.css";
+
+interface SplitOrStealControllerProps {
+  sessionId: string;
+  gameState: any;
+  socket: CustomSocket | null;
+}
+
+const SplitOrStealController: React.FC<SplitOrStealControllerProps> = ({
+  sessionId,
+  gameState,
+  socket,
+}) => {
+  const [phase, setPhase] = useState<string>(gameState?.phase || "waiting");
+  const [choice, setChoice] = useState<string | null>(null);
+  const [timer, setTimer] = useState<number>(0);
+  const [chatInput, setChatInput] = useState<string>("");
+  const [chatMessages, setChatMessages] = useState<any[]>([]);
+  const [result, setResult] = useState<any>(null);
+  const [currentPlayerId, setCurrentPlayerId] = useState<string | null>(null);
+  const [participants, setParticipants] = useState<any[]>(gameState?.participants || []);
+  const [showSettings, setShowSettings] = useState(false);
+  const [newName, setNewName] = useState("");
+
+  useEffect(() => {
+    if (!socket) return;
+
+    const handleState = (state: any) => {
+      setPhase(state.phase);
+      setTimer(state.timer || 0);
+      if (state.participants) setParticipants(state.participants);
+      if (state.currentTurn) setCurrentPlayerId(state.currentTurn);
+      if (state.phase === "reveal" && state.results) {
+        setResult(state.results);
+      }
+      if (state.phase !== "reveal") {
+        setResult(null);
+        setChoice(null);
+      }
+    };
+
+    const handleChat = (data: any) => {
+      setChatMessages((msgs) => [...msgs, data]);
+    };
+
+    socket.on("split-steal-state", handleState);
+    socket.on("split-steal-timer", (t: number) => setTimer(t));
+    socket.on("split-steal-chat", handleChat);
+    return () => {
+      socket.off("split-steal-state", handleState);
+      socket.off("split-steal-timer");
+      socket.off("split-steal-chat", handleChat);
+    };
+  }, [socket]);
+
+  const sendChat = () => {
+    if (socket && chatInput.trim()) {
+      socket.emit("split-steal-chat", sessionId, chatInput.trim());
+      setChatInput("");
+    }
+  };
+
+  const addPlayer = () => {
+    if (socket && newName.trim()) {
+      socket.emit("split-steal-add-player", sessionId, newName.trim());
+      setNewName("");
+    }
+  };
+
+  const removePlayer = (id: string) => {
+    socket?.emit("split-steal-remove-player", sessionId, id);
+  };
+
+  const skipRound = () => {
+    socket?.emit("split-steal-skip", sessionId);
+  };
+
+  const sendChoice = (c: string) => {
+    if (socket && !choice && currentPlayerId) {
+      setChoice(c);
+      socket.emit("split-steal-choice", sessionId, currentPlayerId, c);
+    }
+  };
+
+  const currentPlayer = participants.find((p) => p.id === currentPlayerId);
+
+  return (
+    <div className="split-steal controller">
+      <button className="settings-btn" onClick={() => setShowSettings(!showSettings)}>⚙️</button>
+      {showSettings && (
+        <div className="settings-panel">
+          <div>
+            <input
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              placeholder="Navn"
+            />
+            <button onClick={addPlayer}>Legg til</button>
+          </div>
+          <ul className="player-list">
+            {participants.map((p) => (
+              <li key={p.id}>
+                {p.name}
+                <button onClick={() => removePlayer(p.id)}>x</button>
+              </li>
+            ))}
+          </ul>
+          <button onClick={skipRound}>Hopp til neste runde</button>
+        </div>
+      )}
+      {phase === "negotiation" && (
+        <div>
+      <div className="timer">{timer}</div>
+          <div className="chat-box">
+            <div className="messages">
+              {chatMessages.map((m, i) => (
+                <div key={i} className="msg">
+                  <strong>{m.playerName}:</strong> {m.message}
+                </div>
+              ))}
+            </div>
+            <div className="input-row">
+              <input
+                value={chatInput}
+                onChange={(e) => setChatInput(e.target.value)}
+                placeholder="Si noe..."
+              />
+              <button onClick={sendChat}>Send</button>
+            </div>
+          </div>
+        </div>
+      )}
+      {phase === "decision" && currentPlayerId && (
+        <div className="choice-buttons">
+          <h3>{currentPlayer?.name}</h3>
+          <button
+            className="split-btn"
+            disabled={!!choice}
+            onClick={() => sendChoice("split")}
+          >
+            SPLIT
+          </button>
+          <button
+            className="steal-btn"
+            disabled={!!choice}
+            onClick={() => sendChoice("steal")}
+          >
+            STEAL
+          </button>
+        </div>
+      )}
+      {phase === "decision" && !currentPlayerId && (
+        <div className="waiting">Venter...</div>
+      )}
+      {phase === "reveal" && result && (
+        <div className="reveal">
+          <h3>Resultat: {result.outcome}</h3>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SplitOrStealController;

--- a/frontend/src/components/SplitOrStealDashboard.tsx
+++ b/frontend/src/components/SplitOrStealDashboard.tsx
@@ -1,0 +1,184 @@
+import React, { useEffect, useState } from "react";
+import { CustomSocket } from "../types/socket.types";
+import "../styles/SplitOrSteal.css";
+
+interface SplitOrStealDashboardProps {
+  sessionId: string;
+  gameState: any;
+  socket: CustomSocket | null;
+}
+
+interface Pairing {
+  idA: string;
+  nameA: string;
+  idB?: string;
+  nameB?: string;
+}
+
+const SplitOrStealDashboard: React.FC<SplitOrStealDashboardProps> = ({
+  sessionId,
+  gameState,
+  socket,
+}) => {
+  const [phase, setPhase] = useState<string>(gameState?.phase || "setup");
+  const [currentPair, setCurrentPair] = useState<Pairing | null>(null);
+  const [timer, setTimer] = useState<number>(0);
+  const [results, setResults] = useState<any>(null);
+  const [leaderboard, setLeaderboard] = useState<any>({});
+  const [participants, setParticipants] = useState<any[]>(gameState?.participants || []);
+  const [showSettings, setShowSettings] = useState(false);
+  const [newName, setNewName] = useState("");
+
+  useEffect(() => {
+    if (!socket) return;
+
+    const handleState = (state: any) => {
+      setPhase(state.phase);
+      setTimer(state.timer || 0);
+      if (state.currentPair) {
+        setCurrentPair({
+          idA: state.currentPair[0].id,
+          nameA: state.currentPair[0].name,
+          idB: state.currentPair[1]?.id,
+          nameB: state.currentPair[1]?.name,
+        });
+      } else {
+        setCurrentPair(null);
+      }
+      if (state.leaderboard) setLeaderboard(state.leaderboard);
+      if (state.participants) setParticipants(state.participants);
+      if (state.results) setResults(state.results);
+    };
+
+    socket.on("split-steal-state", handleState);
+    socket.on("split-steal-timer", (t: number) => setTimer(t));
+    return () => {
+      socket.off("split-steal-state", handleState);
+      socket.off("split-steal-timer");
+    };
+  }, [socket]);
+
+  const startCountdown = () => {
+    if (socket) {
+      socket.emit("split-steal-start", sessionId);
+    }
+  };
+
+  const renderPair = () => {
+    if (!currentPair) return null;
+    return (
+      <div className="pair">
+        <span>{currentPair.nameA}</span>
+        <span>vs</span>
+        <span>{currentPair.nameB || "Sitter over"}</span>
+      </div>
+    );
+  };
+
+  const renderResults = () => {
+    if (!results) return null;
+    const [a, b] = results.pair;
+    return (
+      <div className="results">
+        <div className="result">
+          <span>{a.name}</span>
+          <span>{results.outcome}</span>
+          <span>{b ? b.name : ""}</span>
+        </div>
+      </div>
+    );
+  };
+
+  const renderLeaderboard = () => (
+    <div className="leaderboard">
+      {Object.entries(leaderboard).map(([id, stats]: any) => {
+        const player = participants.find((p) => p.id === id);
+        return (
+          <div key={id} className="leaderboard-row">
+            <span>{player?.name}</span>
+            <span>{stats.sips} slurks</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+
+  const addPlayer = () => {
+    if (socket && newName.trim()) {
+      socket.emit("split-steal-add-player", sessionId, newName.trim());
+      setNewName("");
+    }
+  };
+
+  const removePlayer = (id: string) => {
+    socket?.emit("split-steal-remove-player", sessionId, id);
+  };
+
+  const skipRound = () => {
+    socket?.emit("split-steal-skip", sessionId);
+  };
+
+  return (
+    <div className="split-steal dash">
+      <button className="settings-btn" onClick={() => setShowSettings(!showSettings)}>⚙️</button>
+      {showSettings && (
+        <div className="settings-panel">
+          <div>
+            <input
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              placeholder="Navn"
+            />
+            <button onClick={addPlayer}>Legg til</button>
+          </div>
+          <ul className="player-list">
+            {participants.map((p) => (
+              <li key={p.id}>
+                {p.name}
+                <button onClick={() => removePlayer(p.id)}>x</button>
+              </li>
+            ))}
+          </ul>
+          <button onClick={skipRound}>Hopp til neste runde</button>
+        </div>
+      )}
+      {phase === "setup" && (
+        <div className="center">
+          <button onClick={startCountdown} className="btn-primary">
+            Start
+          </button>
+        </div>
+      )}
+      {phase === "countdown" && (
+        <div>
+          <h3>Time until next duel</h3>
+          <div
+            className={`countdown-text ${timer <= 10 ? "flash" : ""}`}
+          >
+            {timer}
+          </div>
+        </div>
+      )}
+      {phase === "negotiation" && (
+        <div>
+          <h2>Forhandling - {timer}</h2>
+          {renderPair()}
+        </div>
+      )}
+      {phase === "decision" && renderPair()}
+      {phase === "reveal" && (
+        <div>
+          <h2>Resultater om {timer}</h2>
+          {timer === 0 && (
+            <>
+              {renderResults()}
+              {renderLeaderboard()}
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SplitOrStealDashboard;

--- a/frontend/src/components/SplitOrStealSetup.tsx
+++ b/frontend/src/components/SplitOrStealSetup.tsx
@@ -1,0 +1,74 @@
+import React, { useState } from "react";
+import { CustomSocket } from "../types/socket.types";
+import "../styles/SplitOrSteal.css";
+
+interface Props {
+  sessionId: string;
+  socket: CustomSocket | null;
+}
+
+const SplitOrStealSetup: React.FC<Props> = ({ sessionId, socket }) => {
+  const [countdown, setCountdown] = useState(30);
+  const [participants, setParticipants] = useState<any[]>([]);
+  const [newName, setNewName] = useState("");
+  const addPlayerLocal = () => {
+    if (!newName.trim()) return;
+    const id = Math.random().toString(36).slice(2, 8);
+    setParticipants((prev) => [...prev, { id, name: newName.trim() }]);
+    setNewName("");
+  };
+
+  const removeLocal = (id: string) => {
+    setParticipants((prev) => prev.filter((p) => p.id !== id));
+  };
+
+  const startGame = () => {
+    if (socket) {
+      socket.emit("split-steal-config", sessionId, {
+        countdownDuration: countdown,
+        participants,
+      });
+    }
+  };
+
+  return (
+    <div className="split-steal setup">
+      <h2>Split or Steal - Oppsett</h2>
+      <div className="config-row">
+        <label>Countdown (sekunder): </label>
+        <input
+          type="number"
+          value={countdown}
+          min={10}
+          max={300}
+          onChange={(e) => setCountdown(parseInt(e.target.value, 10))}
+        />
+      </div>
+      <div className="config-row">
+        <input
+          value={newName}
+          onChange={(e) => setNewName(e.target.value)}
+          placeholder="Navn"
+        />
+        <button onClick={addPlayerLocal}>Legg til spiller</button>
+      </div>
+      <ul className="player-list">
+        {participants.map((p) => (
+          <li key={p.id}>
+            {p.name}
+            <button onClick={() => removeLocal(p.id)}>x</button>
+          </li>
+        ))}
+      </ul>
+      <button
+        className="btn-primary"
+        onClick={startGame}
+        disabled={participants.length < 2}
+      >
+        Start
+      </button>
+    </div>
+  );
+};
+
+export default SplitOrStealSetup;

--- a/frontend/src/styles/SplitOrSteal.css
+++ b/frontend/src/styles/SplitOrSteal.css
@@ -1,0 +1,86 @@
+.split-steal {
+  color: #fff;
+  padding: 20px;
+  text-align: center;
+}
+
+.split-steal .choice-buttons button {
+  font-size: 2rem;
+  margin: 10px;
+  padding: 20px 40px;
+}
+
+.split-steal .chat-box {
+  border: 1px solid #444;
+  padding: 10px;
+  max-height: 150px;
+  overflow-y: auto;
+}
+
+.split-steal .messages {
+  text-align: left;
+  margin-bottom: 10px;
+}
+
+.split-steal .input-row {
+  display: flex;
+}
+
+.split-steal .input-row input {
+  flex: 1;
+  padding: 4px;
+  margin-right: 4px;
+}
+
+.split-steal.dash .pair {
+  margin: 5px 0;
+}
+
+.split-steal.setup {
+  max-width: 400px;
+  margin: 0 auto;
+}
+
+.split-steal .config-row {
+  margin: 10px 0;
+  text-align: left;
+}
+
+.settings-btn {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+}
+
+.settings-panel {
+  position: absolute;
+  top: 40px;
+  left: 10px;
+  background: rgba(0, 0, 0, 0.8);
+  padding: 10px;
+  border: 1px solid #555;
+}
+
+.player-list {
+  list-style: none;
+  padding: 0;
+}
+.player-list li {
+  margin: 4px 0;
+}
+
+.countdown-text {
+  font-size: 4rem;
+  margin-top: 20px;
+}
+
+.countdown-text.flash {
+  color: red;
+  animation: flash 1s steps(2, start) infinite;
+}
+
+@keyframes flash {
+  to {
+    visibility: hidden;
+  }
+}

--- a/server/index.js
+++ b/server/index.js
@@ -6,6 +6,20 @@ require("dotenv").config();
 const spotifyService = require("./spotify");
 const path = require("path");
 const sessionTimers = new Map();
+const {
+  pairPlayers,
+  calculateResults,
+  updateLeaderboard,
+} = require("../splitOrStealGameEngine");
+
+function generatePlayerId(length = 8) {
+  const characters = "ABCDEFGHJKLMNPQRSTUVWXYZ123456789";
+  let result = "";
+  for (let i = 0; i < length; i++) {
+    result += characters.charAt(Math.floor(Math.random() * characters.length));
+  }
+  return result;
+}
 
 function generateSessionId(length = 6) {
   const characters = "ABCDEFGHJKLMNPQRSTUVWXYZ123456789"; // Exclude 0 and O
@@ -168,6 +182,7 @@ const GAME_TYPES = {
   DRINK_OR_JUDGE: "drinkOrJudge", // Added new game type
   BEAT4BEAT: "beat4Beat", // Add this line
   NOT_ALLOWED_TO_LAUGH: "notAllowedToLaugh", // Added new game type
+  SPLIT_OR_STEAL: "splitOrSteal",
   SKJENKEHJULET: "skjenkehjulet",
 };
 
@@ -986,6 +1001,15 @@ io.on("connection", (socket) => {
       };
     } else if (gameType === GAME_TYPES.SKJENKEHJULET) {
       session.gameState = { phase: "idle" };
+    } else if (gameType === GAME_TYPES.SPLIT_OR_STEAL) {
+      session.gameState = {
+        phase: "setup",
+        countdownDuration: 30,
+        timer: 0,
+        participants: [],
+        choices: {},
+        leaderboard: {},
+      };
     }
 
     // Notify all players about the game selection
@@ -2215,6 +2239,85 @@ io.on("connection", (socket) => {
     }
   });
 
+  // ----- Split or Steal events -----
+  socket.on("split-steal-config", (sessionId, config) => {
+    const session = sessions[sessionId];
+    updateSessionActivity(sessionId);
+    if (!session || session.gameType !== GAME_TYPES.SPLIT_OR_STEAL) {
+      socket.emit("error", { message: "Invalid session or game type" });
+      return;
+    }
+    if (socket.id !== session.host) {
+      socket.emit("error", { message: "Only host can configure" });
+      return;
+    }
+    session.gameState = {
+      phase: "countdown",
+      countdownDuration: config.countdownDuration || 30,
+      timer: config.countdownDuration || 30,
+      participants: config.participants || [],
+      choices: {},
+      leaderboard: {},
+    };
+    startSplitStealCountdown(sessionId);
+  });
+
+  socket.on("split-steal-start", (sessionId) => {
+    const session = sessions[sessionId];
+    if (!session || session.gameType !== GAME_TYPES.SPLIT_OR_STEAL) return;
+    if (socket.id !== session.host) return;
+    startSplitStealCountdown(sessionId);
+  });
+
+  socket.on("split-steal-chat", (sessionId, msg) => {
+    const session = sessions[sessionId];
+    if (!session) return;
+    const player = session.players.find((p) => p.id === socket.id);
+    if (!player) return;
+    io.to(sessionId).emit("split-steal-chat", {
+      playerName: player.name,
+      message: msg,
+    });
+  });
+
+  socket.on("split-steal-add-player", (sessionId, name) => {
+    const session = sessions[sessionId];
+    if (!session || session.gameType !== GAME_TYPES.SPLIT_OR_STEAL) return;
+    const newPlayer = { id: generatePlayerId(), name };
+    session.gameState.participants.push(newPlayer);
+    io.to(sessionId).emit("split-steal-state", session.gameState);
+  });
+
+  socket.on("split-steal-remove-player", (sessionId, playerId) => {
+    const session = sessions[sessionId];
+    if (!session || session.gameType !== GAME_TYPES.SPLIT_OR_STEAL) return;
+    session.gameState.participants = session.gameState.participants.filter(
+      (p) => p.id !== playerId
+    );
+    delete session.gameState.leaderboard[playerId];
+    io.to(sessionId).emit("split-steal-state", session.gameState);
+  });
+
+  socket.on("split-steal-skip", (sessionId) => {
+    const session = sessions[sessionId];
+    if (!session || session.gameType !== GAME_TYPES.SPLIT_OR_STEAL) return;
+    startSplitStealCountdown(sessionId);
+  });
+
+  socket.on("split-steal-choice", (sessionId, playerId, choice) => {
+    const session = sessions[sessionId];
+    if (!session || session.gameType !== GAME_TYPES.SPLIT_OR_STEAL) return;
+    const gs = session.gameState;
+    if (gs.currentTurn !== playerId) return;
+    gs.choices[playerId] = choice;
+    if (gs.currentTurn === gs.currentPair[0].id && gs.currentPair[1]) {
+      gs.currentTurn = gs.currentPair[1].id;
+      io.to(sessionId).emit("split-steal-state", gs);
+    } else {
+      startReveal(sessionId);
+    }
+  });
+
   // End Lambo (host only)
   socket.on("end-lambo", (sessionId) => {
     const session = sessions[sessionId];
@@ -2580,6 +2683,79 @@ function moveToNextStatement(sessionId) {
     statementIndex: session.gameState.currentStatementIndex,
     totalStatements: session.gameState.availableStatements.length,
   });
+}
+
+// ----- Split or Steal basic flow -----
+function startSplitStealCountdown(sessionId) {
+  const session = sessions[sessionId];
+  if (!session) return;
+  clearInterval(session.gameState.timerId);
+  session.gameState.phase = "countdown";
+  session.gameState.timer = session.gameState.countdownDuration;
+  session.gameState.timerId = setInterval(() => {
+    const s = sessions[sessionId];
+    if (!s) return clearInterval(session.gameState.timerId);
+    s.gameState.timer -= 1;
+    io.to(sessionId).emit("split-steal-timer", s.gameState.timer);
+    if (s.gameState.timer <= 0) {
+      clearInterval(s.gameState.timerId);
+      startNegotiation(sessionId);
+    }
+  }, 1000);
+  io.to(sessionId).emit("split-steal-state", session.gameState);
+}
+
+function startNegotiation(sessionId) {
+  const session = sessions[sessionId];
+  if (!session) return;
+  const [pair] = pairPlayers(
+    session.gameState.participants.map((id) =>
+      session.players.find((p) => p.id === id)
+    )
+  );
+  session.gameState.currentPair = pair;
+  session.gameState.choices = {};
+  session.gameState.phase = "negotiation";
+  session.gameState.timer = 60;
+  session.gameState.timerId = setInterval(() => {
+    const s = sessions[sessionId];
+    if (!s) return clearInterval(session.gameState.timerId);
+    s.gameState.timer -= 1;
+    io.to(sessionId).emit("split-steal-timer", s.gameState.timer);
+    if (s.gameState.timer <= 0) {
+      clearInterval(s.gameState.timerId);
+      s.gameState.phase = "decision";
+      s.gameState.currentTurn = pair[0].id;
+      io.to(sessionId).emit("split-steal-state", s.gameState);
+    }
+  }, 1000);
+  io.to(sessionId).emit("split-steal-state", session.gameState);
+}
+
+function startReveal(sessionId) {
+  const session = sessions[sessionId];
+  if (!session) return;
+  session.gameState.phase = "reveal";
+  session.gameState.timer = 10;
+  session.gameState.timerId = setInterval(() => {
+    const s = sessions[sessionId];
+    if (!s) return clearInterval(session.gameState.timerId);
+    s.gameState.timer -= 1;
+    io.to(sessionId).emit("split-steal-timer", s.gameState.timer);
+    if (s.gameState.timer <= 0) {
+      clearInterval(s.gameState.timerId);
+      const result = calculateResults([
+        s.gameState.currentPair,
+      ], s.gameState.choices)[0];
+      s.gameState.leaderboard = updateLeaderboard(
+        s.gameState.leaderboard,
+        [result]
+      );
+      s.gameState.results = result;
+      io.to(sessionId).emit("split-steal-state", s.gameState);
+    }
+  }, 1000);
+  io.to(sessionId).emit("split-steal-state", session.gameState);
 }
 
 function shuffleArray(array) {

--- a/splitOrStealGameEngine.js
+++ b/splitOrStealGameEngine.js
@@ -1,0 +1,72 @@
+// Basic game engine utilities for Split or Steal
+
+function pairPlayers(players) {
+  const shuffled = players.slice().sort(() => Math.random() - 0.5);
+  const pairs = [];
+  while (shuffled.length > 1) {
+    const a = shuffled.shift();
+    const b = shuffled.shift();
+    pairs.push([a, b]);
+  }
+  if (shuffled.length === 1) {
+    pairs.push([shuffled.shift(), null]);
+  }
+  return pairs;
+}
+
+function calculateResults(pairs, choices) {
+  return pairs.map(([a, b]) => {
+    if (!b) {
+      return { pair: [a], outcome: 'solo', sips: {} };
+    }
+    const cA = choices[a.id];
+    const cB = choices[b.id];
+    let outcome = '';
+    const sips = {};
+    if (cA === 'split' && cB === 'split') {
+      outcome = 'split-split';
+      sips[a.id] = 1;
+      sips[b.id] = 1;
+    } else if (cA === 'split' && cB === 'steal') {
+      outcome = 'split-steal';
+      sips[a.id] = 3;
+      sips[b.id] = 0;
+    } else if (cA === 'steal' && cB === 'split') {
+      outcome = 'steal-split';
+      sips[a.id] = 0;
+      sips[b.id] = 3;
+    } else {
+      outcome = 'steal-steal';
+      sips[a.id] = 2;
+      sips[b.id] = 2;
+    }
+    return { pair: [a, b], outcome, sips };
+  });
+}
+
+function updateLeaderboard(leaderboard, results) {
+  results.forEach((res) => {
+    Object.entries(res.sips).forEach(([id, s]) => {
+      if (!leaderboard[id]) {
+        leaderboard[id] = { sips: 0, steals: 0, splits: 0 };
+      }
+      leaderboard[id].sips += s;
+    });
+    if (res.outcome === 'split-steal') {
+      const [a, b] = res.pair;
+      leaderboard[b.id].steals = (leaderboard[b.id].steals || 0) + 1;
+      leaderboard[a.id].splits = (leaderboard[a.id].splits || 0) + 1;
+    } else if (res.outcome === 'steal-split') {
+      const [a, b] = res.pair;
+      leaderboard[a.id].steals = (leaderboard[a.id].steals || 0) + 1;
+      leaderboard[b.id].splits = (leaderboard[b.id].splits || 0) + 1;
+    } else if (res.outcome === 'split-split') {
+      const [a, b] = res.pair;
+      leaderboard[a.id].splits = (leaderboard[a.id].splits || 0) + 1;
+      leaderboard[b.id].splits = (leaderboard[b.id].splits || 0) + 1;
+    }
+  });
+  return leaderboard;
+}
+
+module.exports = { pairPlayers, calculateResults, updateLeaderboard };


### PR DESCRIPTION
## Summary
- allow host to input participant names during setup
- show settings button on dashboard and controller for adding/removing players and skipping rounds
- update Split or Steal controller to operate a single device for all players
- keep participants list on the server and handle add/remove/skip events

## Testing
- `npm test --prefix frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885f184c4b0832c8ad0d8815bb95f07