### PR TITLE
Add manual player management to Split or Steal

### DIFF
--- a/frontend/src/components/Game.tsx
+++ b/frontend/src/components/Game.tsx
@@ -11,6 +11,9 @@ import Beat4Beat from "./Beat4Beat";
 import LamboScreen from "./LamboScreen"; // Import the new LamboScreen component
 import NotAllowedToLaugh from "./NotAllowedToLaugh";
 import Skjenkehjulet, { SkjenkehjuletHandle } from "./Skjenkehjulet";
+import SplitOrStealDashboard from "./SplitOrStealDashboard";
+import SplitOrStealController from "./SplitOrStealController";
+import SplitOrStealSetup from "./SplitOrStealSetup";
 
 // Game type constants (must match server constants)
 const GAME_TYPES = {
@@ -20,6 +23,7 @@ const GAME_TYPES = {
   DRINK_OR_JUDGE: "drinkOrJudge",
   BEAT4BEAT: "beat4Beat",
   NOT_ALLOWED_TO_LAUGH: "notAllowedToLaugh", // Added new game type
+  SPLIT_OR_STEAL: "splitOrSteal",
   SKJENKEHJULET: "skjenkehjulet",
 };
 
@@ -387,6 +391,31 @@ const Game: React.FC = () => {
             restartGame={restartGame}
             leaveSession={confirmLeaveSession}
             returnToLobby={returnToLobby}
+          />
+        );
+      case GAME_TYPES.SPLIT_OR_STEAL:
+        if (sessionData.isHost) {
+          if (sessionData.gameState?.phase === "setup") {
+            return (
+              <SplitOrStealSetup
+                sessionId={sessionData.sessionId}
+                socket={socket}
+              />
+            );
+          }
+          return (
+            <SplitOrStealDashboard
+              sessionId={sessionData.sessionId}
+              gameState={sessionData.gameState}
+              socket={socket}
+            />
+          );
+        }
+        return (
+          <SplitOrStealController
+            sessionId={sessionData.sessionId}
+            gameState={sessionData.gameState}
+            socket={socket}
           />
         );
       case GAME_TYPES.SKJENKEHJULET:

--- a/frontend/src/components/GameLobby.tsx
+++ b/frontend/src/components/GameLobby.tsx
@@ -100,6 +100,12 @@ const GameLobby: React.FC<GameLobbyProps> = ({
       icon: "😂",
       color: "#6200ea",
     },
+    {
+      id: "splitOrSteal",
+      name: "Split or Steal",
+      icon: "💰",
+      color: "#3f51b5",
+    },
     { id: "skjenkehjulet", name: "Skjenkehjulet", icon: "🍻", color: "#ff9800" },
   ];
 

--- a/frontend/src/components/SplitOrStealController.tsx
+++ b/frontend/src/components/SplitOrStealController.tsx
@@ -1,0 +1,157 @@
+import React, { useEffect, useState } from "react";
+import { CustomSocket } from "../types/socket.types";
+import "../styles/SplitOrSteal.css";
+
+interface SplitOrStealControllerProps {
+  sessionId: string;
+  gameState: any;
+  socket: CustomSocket | null;
+}
+
+const SplitOrStealController: React.FC<SplitOrStealControllerProps> = ({
+  sessionId,
+  gameState,
+  socket,
+}) => {
+  const [phase, setPhase] = useState<string>(gameState?.phase || "waiting");
+  const [choice, setChoice] = useState<string | null>(null);
+  const [timer, setTimer] = useState<number>(0);
+  const [chatInput, setChatInput] = useState<string>("");
+  const [chatMessages, setChatMessages] = useState<any[]>([]);
+  const [result, setResult] = useState<any>(null);
+  const [currentTurn, setCurrentTurn] = useState<any>(null);
+  const [participants, setParticipants] = useState<any[]>(gameState?.participants || []);
+  const [showSettings, setShowSettings] = useState(false);
+  const [newPlayer, setNewPlayer] = useState("");
+
+  useEffect(() => {
+    if (!socket) return;
+
+    const handleState = (state: any) => {
+      setPhase(state.phase);
+      setTimer(state.timer || 0);
+      setCurrentTurn(state.currentTurn);
+      if (state.participants) setParticipants(state.participants);
+      if (state.phase === "reveal" && state.results) {
+        setResult(state.results);
+      } else {
+        setResult(null);
+      }
+      setChoice(null);
+    };
+
+    const handleChat = (data: any) => {
+      setChatMessages((msgs) => [...msgs, data]);
+    };
+
+    socket.on("split-steal-state", handleState);
+    socket.on("split-steal-timer", (t: number) => setTimer(t));
+    socket.on("split-steal-chat", handleChat);
+    return () => {
+      socket.off("split-steal-state", handleState);
+      socket.off("split-steal-timer");
+      socket.off("split-steal-chat", handleChat);
+    };
+  }, [socket]);
+
+  const sendChat = () => {
+    if (socket && chatInput.trim()) {
+      socket.emit("split-steal-chat", sessionId, chatInput.trim());
+      setChatInput("");
+    }
+  };
+
+  const sendChoice = (c: string) => {
+    if (socket && !choice && currentTurn) {
+      setChoice(c);
+      socket.emit("split-steal-choice", sessionId, currentTurn.id, c);
+    }
+  };
+
+  return (
+    <div className="split-steal controller">
+      <button className="settings-btn" onClick={() => setShowSettings((s) => !s)}>
+        ⚙️
+      </button>
+      {showSettings && (
+        <div className="settings-panel">
+          <div className="add-player-row">
+            <input
+              type="text"
+              value={newPlayer}
+              onChange={(e) => setNewPlayer(e.target.value)}
+              placeholder="Navn"
+            />
+            <button
+              onClick={() => {
+                if (socket && newPlayer.trim()) {
+                  socket.emit("split-steal-add-player", sessionId, newPlayer.trim());
+                  setNewPlayer("");
+                }
+              }}
+            >
+              Legg til
+            </button>
+          </div>
+          {participants.map((p) => (
+            <div key={p.id} className="participant-row">
+              {p.name}
+              <button onClick={() => socket?.emit("split-steal-remove-player", sessionId, p.id)}>
+                X
+              </button>
+            </div>
+          ))}
+          <button onClick={() => socket?.emit("split-steal-skip", sessionId)}>Hopp over runde</button>
+        </div>
+      )}
+      {phase === "negotiation" && (
+        <div>
+      <div className="timer">{timer}</div>
+          <div className="chat-box">
+            <div className="messages">
+              {chatMessages.map((m, i) => (
+                <div key={i} className="msg">
+                  <strong>{m.playerName}:</strong> {m.message}
+                </div>
+              ))}
+            </div>
+            <div className="input-row">
+              <input
+                value={chatInput}
+                onChange={(e) => setChatInput(e.target.value)}
+                placeholder="Si noe..."
+              />
+              <button onClick={sendChat}>Send</button>
+            </div>
+          </div>
+        </div>
+      )}
+      {phase === "decision" && currentTurn && (
+        <div className="choice-buttons">
+          <h3>{currentTurn.name} velger</h3>
+          <button
+            className="split-btn"
+            disabled={!!choice}
+            onClick={() => sendChoice("split")}
+          >
+            SPLIT
+          </button>
+          <button
+            className="steal-btn"
+            disabled={!!choice}
+            onClick={() => sendChoice("steal")}
+          >
+            STEAL
+          </button>
+        </div>
+      )}
+      {phase === "reveal" && result && (
+        <div className="reveal">
+          <h3>Resultat: {result.outcome}</h3>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SplitOrStealController;

--- a/frontend/src/components/SplitOrStealDashboard.tsx
+++ b/frontend/src/components/SplitOrStealDashboard.tsx
@@ -1,0 +1,189 @@
+import React, { useEffect, useState } from "react";
+import { CustomSocket } from "../types/socket.types";
+import "../styles/SplitOrSteal.css";
+
+interface SplitOrStealDashboardProps {
+  sessionId: string;
+  gameState: any;
+  socket: CustomSocket | null;
+}
+
+interface Pairing {
+  idA: string;
+  nameA: string;
+  idB?: string;
+  nameB?: string;
+}
+
+const SplitOrStealDashboard: React.FC<SplitOrStealDashboardProps> = ({
+  sessionId,
+  gameState,
+  socket,
+}) => {
+  const [phase, setPhase] = useState<string>(gameState?.phase || "setup");
+  const [currentPair, setCurrentPair] = useState<Pairing | null>(null);
+  const [timer, setTimer] = useState<number>(0);
+  const [results, setResults] = useState<any>(null);
+  const [leaderboard, setLeaderboard] = useState<any>({});
+  const [participants, setParticipants] = useState<any[]>(gameState?.participants || []);
+  const [showSettings, setShowSettings] = useState(false);
+  const [newPlayer, setNewPlayer] = useState("");
+
+  useEffect(() => {
+    if (!socket) return;
+
+    const handleState = (state: any) => {
+      setPhase(state.phase);
+      setTimer(state.timer || 0);
+      if (state.currentPair) {
+        setCurrentPair({
+          idA: state.currentPair[0].id,
+          nameA: state.currentPair[0].name,
+          idB: state.currentPair[1]?.id,
+          nameB: state.currentPair[1]?.name,
+        });
+      } else {
+        setCurrentPair(null);
+      }
+      if (state.leaderboard) setLeaderboard(state.leaderboard);
+      if (state.participants) setParticipants(state.participants);
+      if (state.results) setResults(state.results);
+    };
+
+    socket.on("split-steal-state", handleState);
+    socket.on("split-steal-timer", (t: number) => setTimer(t));
+    return () => {
+      socket.off("split-steal-state", handleState);
+      socket.off("split-steal-timer");
+    };
+  }, [socket]);
+
+  const startCountdown = () => {
+    if (socket) {
+      socket.emit("split-steal-start", sessionId);
+    }
+  };
+
+  const addPlayer = () => {
+    if (socket && newPlayer.trim()) {
+      socket.emit("split-steal-add-player", sessionId, newPlayer.trim());
+      setNewPlayer("");
+    }
+  };
+
+  const removePlayer = (id: string) => {
+    if (socket) {
+      socket.emit("split-steal-remove-player", sessionId, id);
+    }
+  };
+
+  const skipRound = () => {
+    if (socket) {
+      socket.emit("split-steal-skip", sessionId);
+    }
+  };
+
+  const renderPair = () => {
+    if (!currentPair) return null;
+    return (
+      <div className="pair">
+        <span>{currentPair.nameA}</span>
+        <span>vs</span>
+        <span>{currentPair.nameB || "Sitter over"}</span>
+      </div>
+    );
+  };
+
+  const renderResults = () => {
+    if (!results) return null;
+    const [a, b] = results.pair;
+    return (
+      <div className="results">
+        <div className="result">
+          <span>{a.name}</span>
+          <span>{results.outcome}</span>
+          <span>{b ? b.name : ""}</span>
+        </div>
+      </div>
+    );
+  };
+
+  const renderLeaderboard = () => (
+    <div className="leaderboard">
+      {Object.entries(leaderboard).map(([id, stats]: any) => {
+        const player = participants.find((p) => p.id === id);
+        return (
+          <div key={id} className="leaderboard-row">
+            <span>{player?.name}</span>
+            <span>{stats.sips} slurks</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+
+  return (
+    <div className="split-steal dash">
+      <button className="settings-btn" onClick={() => setShowSettings((s) => !s)}>
+        ⚙️
+      </button>
+      {showSettings && (
+        <div className="settings-panel">
+          <div className="add-player-row">
+            <input
+              type="text"
+              value={newPlayer}
+              onChange={(e) => setNewPlayer(e.target.value)}
+              placeholder="Navn"
+            />
+            <button onClick={addPlayer}>Legg til</button>
+          </div>
+          {participants.map((p) => (
+            <div key={p.id} className="participant-row">
+              {p.name}
+              <button onClick={() => removePlayer(p.id)}>X</button>
+            </div>
+          ))}
+          <button onClick={skipRound}>Hopp over runde</button>
+        </div>
+      )}
+      {phase === "setup" && (
+        <div className="center">
+          <button onClick={startCountdown} className="btn-primary">
+            Start
+          </button>
+        </div>
+      )}
+      {phase === "countdown" && (
+        <div>
+          <h3>Time until next duel</h3>
+          <div
+            className={`countdown-text ${timer <= 10 ? "flash" : ""}`}
+          >
+            {timer}
+          </div>
+        </div>
+      )}
+      {phase === "negotiation" && (
+        <div>
+          <h2>Forhandling - {timer}</h2>
+          {renderPair()}
+        </div>
+      )}
+      {phase === "decision" && renderPair()}
+      {phase === "reveal" && (
+        <div>
+          <h2>Resultater om {timer}</h2>
+          {timer === 0 && (
+            <>
+              {renderResults()}
+              {renderLeaderboard()}
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SplitOrStealDashboard;

--- a/frontend/src/components/SplitOrStealSetup.tsx
+++ b/frontend/src/components/SplitOrStealSetup.tsx
@@ -1,0 +1,72 @@
+import React, { useState } from "react";
+import { CustomSocket } from "../types/socket.types";
+import "../styles/SplitOrSteal.css";
+
+interface Props {
+  sessionId: string;
+  socket: CustomSocket | null;
+}
+
+const SplitOrStealSetup: React.FC<Props> = ({ sessionId, socket }) => {
+  const [countdown, setCountdown] = useState(30);
+  const [newPlayer, setNewPlayer] = useState("");
+  const [participants, setParticipants] = useState<string[]>([]);
+
+  const addPlayer = () => {
+    if (!newPlayer.trim()) return;
+    setParticipants((prev) => [...prev, newPlayer.trim()]);
+    setNewPlayer("");
+  };
+
+  const removePlayer = (name: string) => {
+    setParticipants((prev) => prev.filter((p) => p !== name));
+  };
+
+  const startGame = () => {
+    if (socket) {
+      socket.emit("split-steal-config", sessionId, {
+        countdownDuration: countdown,
+        participants,
+      });
+    }
+  };
+
+  return (
+    <div className="split-steal setup">
+      <h2>Split or Steal - Oppsett</h2>
+      <div className="config-row">
+        <label>Countdown (sekunder): </label>
+        <input
+          type="number"
+          value={countdown}
+          min={10}
+          max={300}
+          onChange={(e) => setCountdown(parseInt(e.target.value, 10))}
+        />
+      </div>
+      <div className="config-row">
+        <h3>Deltakere</h3>
+        <div className="add-player-row">
+          <input
+            type="text"
+            value={newPlayer}
+            onChange={(e) => setNewPlayer(e.target.value)}
+            placeholder="Navn"
+          />
+          <button onClick={addPlayer}>Legg til</button>
+        </div>
+        {participants.map((p) => (
+          <div key={p} className="participant-row">
+            {p}
+            <button onClick={() => removePlayer(p)}>X</button>
+          </div>
+        ))}
+      </div>
+      <button className="btn-primary" onClick={startGame} disabled={participants.length < 2}>
+        Start
+      </button>
+    </div>
+  );
+};
+
+export default SplitOrStealSetup;

--- a/frontend/src/styles/SplitOrSteal.css
+++ b/frontend/src/styles/SplitOrSteal.css
@@ -1,0 +1,95 @@
+.split-steal {
+  color: #fff;
+  padding: 20px;
+  text-align: center;
+}
+
+.split-steal .choice-buttons button {
+  font-size: 2rem;
+  margin: 10px;
+  padding: 20px 40px;
+}
+
+.split-steal .chat-box {
+  border: 1px solid #444;
+  padding: 10px;
+  max-height: 150px;
+  overflow-y: auto;
+}
+
+.split-steal .messages {
+  text-align: left;
+  margin-bottom: 10px;
+}
+
+.split-steal .input-row {
+  display: flex;
+}
+
+.split-steal .input-row input {
+  flex: 1;
+  padding: 4px;
+  margin-right: 4px;
+}
+
+.split-steal.dash .pair {
+  margin: 5px 0;
+}
+
+.split-steal.setup {
+  max-width: 400px;
+  margin: 0 auto;
+}
+
+.split-steal .config-row {
+  margin: 10px 0;
+  text-align: left;
+}
+
+.split-steal .add-player-row {
+  display: flex;
+  margin-bottom: 10px;
+}
+
+.split-steal .add-player-row input {
+  flex: 1;
+  margin-right: 4px;
+}
+
+.split-steal .participant-row {
+  display: flex;
+  justify-content: space-between;
+  margin: 4px 0;
+}
+
+.countdown-text {
+  font-size: 4rem;
+  margin-top: 20px;
+}
+
+.countdown-text.flash {
+  color: red;
+  animation: flash 1s steps(2, start) infinite;
+}
+
+.settings-btn {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+}
+
+.settings-panel {
+  background: rgba(0, 0, 0, 0.8);
+  padding: 10px;
+  position: absolute;
+  top: 40px;
+  left: 10px;
+  z-index: 10;
+  width: 200px;
+}
+
+@keyframes flash {
+  to {
+    visibility: hidden;
+  }
+}

--- a/splitOrStealGameEngine.js
+++ b/splitOrStealGameEngine.js
@@ -1,0 +1,72 @@
+// Basic game engine utilities for Split or Steal
+
+function pairPlayers(players) {
+  const shuffled = players.slice().sort(() => Math.random() - 0.5);
+  const pairs = [];
+  while (shuffled.length > 1) {
+    const a = shuffled.shift();
+    const b = shuffled.shift();
+    pairs.push([a, b]);
+  }
+  if (shuffled.length === 1) {
+    pairs.push([shuffled.shift(), null]);
+  }
+  return pairs;
+}
+
+function calculateResults(pairs, choices) {
+  return pairs.map(([a, b]) => {
+    if (!b) {
+      return { pair: [a], outcome: 'solo', sips: {} };
+    }
+    const cA = choices[a.id];
+    const cB = choices[b.id];
+    let outcome = '';
+    const sips = {};
+    if (cA === 'split' && cB === 'split') {
+      outcome = 'split-split';
+      sips[a.id] = 1;
+      sips[b.id] = 1;
+    } else if (cA === 'split' && cB === 'steal') {
+      outcome = 'split-steal';
+      sips[a.id] = 3;
+      sips[b.id] = 0;
+    } else if (cA === 'steal' && cB === 'split') {
+      outcome = 'steal-split';
+      sips[a.id] = 0;
+      sips[b.id] = 3;
+    } else {
+      outcome = 'steal-steal';
+      sips[a.id] = 2;
+      sips[b.id] = 2;
+    }
+    return { pair: [a, b], outcome, sips };
+  });
+}
+
+function updateLeaderboard(leaderboard, results) {
+  results.forEach((res) => {
+    Object.entries(res.sips).forEach(([id, s]) => {
+      if (!leaderboard[id]) {
+        leaderboard[id] = { sips: 0, steals: 0, splits: 0 };
+      }
+      leaderboard[id].sips += s;
+    });
+    if (res.outcome === 'split-steal') {
+      const [a, b] = res.pair;
+      leaderboard[b.id].steals = (leaderboard[b.id].steals || 0) + 1;
+      leaderboard[a.id].splits = (leaderboard[a.id].splits || 0) + 1;
+    } else if (res.outcome === 'steal-split') {
+      const [a, b] = res.pair;
+      leaderboard[a.id].steals = (leaderboard[a.id].steals || 0) + 1;
+      leaderboard[b.id].splits = (leaderboard[b.id].splits || 0) + 1;
+    } else if (res.outcome === 'split-split') {
+      const [a, b] = res.pair;
+      leaderboard[a.id].splits = (leaderboard[a.id].splits || 0) + 1;
+      leaderboard[b.id].splits = (leaderboard[b.id].splits || 0) + 1;
+    }
+  });
+  return leaderboard;
+}
+
+module.exports = { pairPlayers, calculateResults, updateLeaderboard };


### PR DESCRIPTION
## Summary
- rework SplitOrSteal setup to manually enter participants
- add settings panels on dashboard and controller for editing players or skipping rounds
- adjust dashboard/controller to use participant list and show current turn
- update server game flow to store participants independently and accept control-device choices

## Testing
- `npm test --prefix frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885f184c4b0832c8ad0d8815bb95f07