### PR TITLE
Fix split or steal decision buttons

### DIFF
--- a/frontend/src/components/Game.tsx
+++ b/frontend/src/components/Game.tsx
@@ -11,6 +11,9 @@ import Beat4Beat from "./Beat4Beat";
 import LamboScreen from "./LamboScreen"; // Import the new LamboScreen component
 import NotAllowedToLaugh from "./NotAllowedToLaugh";
 import Skjenkehjulet, { SkjenkehjuletHandle } from "./Skjenkehjulet";
+import SplitOrStealDashboard from "./SplitOrStealDashboard";
+import SplitOrStealController from "./SplitOrStealController";
+import SplitOrStealSetup from "./SplitOrStealSetup";
 
 // Game type constants (must match server constants)
 const GAME_TYPES = {
@@ -20,6 +23,7 @@ const GAME_TYPES = {
   DRINK_OR_JUDGE: "drinkOrJudge",
   BEAT4BEAT: "beat4Beat",
   NOT_ALLOWED_TO_LAUGH: "notAllowedToLaugh", // Added new game type
+  SPLIT_OR_STEAL: "splitOrSteal",
   SKJENKEHJULET: "skjenkehjulet",
 };
 
@@ -187,6 +191,13 @@ const Game: React.FC = () => {
       }));
     };
 
+    const handleSplitStealState = (state: any) => {
+      setSessionData((prev) => ({
+        ...prev,
+        gameState: state,
+      }));
+    };
+
     const handleDisconnect = (reason: string) => {
       console.log("Socket disconnected:", reason);
       // Only set error if we're not already reconnecting
@@ -222,6 +233,7 @@ const Game: React.FC = () => {
     socket.on("host-changed", handleHostChanged);
     socket.on("error", handleError);
     socket.on("game-restarted", handleGameRestarted);
+    socket.on("split-steal-state", handleSplitStealState);
     socket.on("disconnect", handleDisconnect);
 
     // Lambo event listeners
@@ -243,6 +255,7 @@ const Game: React.FC = () => {
       socket.off("host-changed", handleHostChanged);
       socket.off("error", handleError);
       socket.off("game-restarted", handleGameRestarted);
+      socket.off("split-steal-state", handleSplitStealState);
       socket.off("disconnect", handleDisconnect);
 
       // Lambo cleanup
@@ -387,6 +400,31 @@ const Game: React.FC = () => {
             restartGame={restartGame}
             leaveSession={confirmLeaveSession}
             returnToLobby={returnToLobby}
+          />
+        );
+      case GAME_TYPES.SPLIT_OR_STEAL:
+        if (sessionData.isHost) {
+          if (sessionData.gameState?.phase === "setup") {
+            return (
+              <SplitOrStealSetup
+                sessionId={sessionData.sessionId}
+                socket={socket}
+              />
+            );
+          }
+          return (
+            <SplitOrStealDashboard
+              sessionId={sessionData.sessionId}
+              gameState={sessionData.gameState}
+              socket={socket}
+            />
+          );
+        }
+        return (
+          <SplitOrStealController
+            sessionId={sessionData.sessionId}
+            gameState={sessionData.gameState}
+            socket={socket}
           />
         );
       case GAME_TYPES.SKJENKEHJULET:

--- a/frontend/src/components/GameLobby.tsx
+++ b/frontend/src/components/GameLobby.tsx
@@ -100,6 +100,12 @@ const GameLobby: React.FC<GameLobbyProps> = ({
       icon: "😂",
       color: "#6200ea",
     },
+    {
+      id: "splitOrSteal",
+      name: "Split or Steal",
+      icon: "💰",
+      color: "#3f51b5",
+    },
     { id: "skjenkehjulet", name: "Skjenkehjulet", icon: "🍻", color: "#ff9800" },
   ];
 

--- a/frontend/src/components/SplitOrStealController.tsx
+++ b/frontend/src/components/SplitOrStealController.tsx
@@ -1,0 +1,104 @@
+import React, { useEffect, useState } from "react";
+import { CustomSocket } from "../types/socket.types";
+import "../styles/SplitOrSteal.css";
+
+interface SplitOrStealControllerProps {
+  sessionId: string;
+  gameState: any;
+  socket: CustomSocket | null;
+}
+
+const SplitOrStealController: React.FC<SplitOrStealControllerProps> = ({
+  sessionId,
+  gameState,
+  socket,
+}) => {
+  const [phase, setPhase] = useState<string>(gameState?.phase || "waiting");
+  const [choice, setChoice] = useState<string | null>(null);
+  const [timer, setTimer] = useState<number>(0);
+  const [result, setResult] = useState<any>(null);
+  const [currentPlayer, setCurrentPlayer] = useState<string>("");
+  const [showSettings, setShowSettings] = useState(false);
+  const [newName, setNewName] = useState("");
+  const [leaderboard, setLeaderboard] = useState<any>({});
+  const [participants, setParticipants] = useState<any[]>(gameState?.participants || []);
+
+  useEffect(() => {
+    if (!socket) return;
+
+    const handleState = (state: any) => {
+      setPhase(state.phase);
+      setTimer(state.timer || 0);
+      if (state.participants) setParticipants(state.participants);
+      if (state.leaderboard) setLeaderboard(state.leaderboard);
+      setCurrentPlayer(state.currentTurnName || "");
+      if (state.phase === "reveal" && state.results) {
+        setResult(state.results);
+      } else {
+        setResult(null);
+      }
+      if (state.phase !== "decision" || state.currentTurnName !== currentPlayer) {
+        setChoice(null);
+      }
+    };
+
+    socket.on("split-steal-state", handleState);
+    socket.on("split-steal-timer", (t: number) => setTimer(t));
+    return () => {
+      socket.off("split-steal-state", handleState);
+      socket.off("split-steal-timer");
+    };
+  }, [socket]);
+
+  const sendChoice = (c: string) => {
+    if (socket && !choice) {
+      setChoice(c);
+      socket.emit("split-steal-choice", sessionId, c);
+    }
+  };
+
+  return (
+    <div className="split-steal controller">
+      <button className="settings-btn" onClick={() => setShowSettings(!showSettings)}>⚙️</button>
+      {showSettings && (
+        <div className="settings-panel">
+          <h3>Innstillinger</h3>
+          <div className="add-player-row">
+            <input
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              placeholder="Navn"
+            />
+            <button onClick={() => {socket?.emit('split-steal-add-player', sessionId, newName); setNewName('');}}>Legg til</button>
+          </div>
+          {participants.map((p) => (
+            <div key={p.id} className="player-row">
+              {p.name}
+              <button onClick={() => socket?.emit('split-steal-remove-player', sessionId, p.id)}>x</button>
+            </div>
+          ))}
+          <button onClick={() => socket?.emit('split-steal-skip', sessionId)}>Hopp over runde</button>
+        </div>
+      )}
+      {phase === "negotiation" && <div className="timer">{timer}</div>}
+      {phase === "decision" && (
+        <div className="choice-buttons">
+          <h3>{currentPlayer}</h3>
+          <button className="split-btn" disabled={!!choice} onClick={() => sendChoice('split')}>
+            SPLIT
+          </button>
+          <button className="steal-btn" disabled={!!choice} onClick={() => sendChoice('steal')}>
+            STEAL
+          </button>
+        </div>
+      )}
+      {phase === "reveal" && result && (
+        <div className="reveal">
+          <h3>Resultat: {result.outcome}</h3>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SplitOrStealController;

--- a/frontend/src/components/SplitOrStealDashboard.tsx
+++ b/frontend/src/components/SplitOrStealDashboard.tsx
@@ -1,0 +1,195 @@
+import React, { useEffect, useState } from "react";
+import { CustomSocket } from "../types/socket.types";
+import "../styles/SplitOrSteal.css";
+
+interface SplitOrStealDashboardProps {
+  sessionId: string;
+  gameState: any;
+  socket: CustomSocket | null;
+}
+
+interface Pairing {
+  idA: string;
+  nameA: string;
+  idB?: string;
+  nameB?: string;
+}
+
+const SplitOrStealDashboard: React.FC<SplitOrStealDashboardProps> = ({
+  sessionId,
+  gameState,
+  socket,
+}) => {
+  const [phase, setPhase] = useState<string>(gameState?.phase || "setup");
+  const [currentPair, setCurrentPair] = useState<Pairing | null>(null);
+  const [timer, setTimer] = useState<number>(0);
+  const [results, setResults] = useState<any>(null);
+  const [leaderboard, setLeaderboard] = useState<any>({});
+  const [participants, setParticipants] = useState<any[]>(gameState?.participants || []);
+  const [showSettings, setShowSettings] = useState(false);
+  const [newName, setNewName] = useState("");
+
+  useEffect(() => {
+    if (!socket) return;
+
+    const handleState = (state: any) => {
+      setPhase(state.phase);
+      setTimer(state.timer || 0);
+      if (state.participants) setParticipants(state.participants);
+      if (state.currentPair) {
+        setCurrentPair({
+          idA: state.currentPair[0].id,
+          nameA: state.currentPair[0].name,
+          idB: state.currentPair[1]?.id,
+          nameB: state.currentPair[1]?.name,
+        });
+      } else {
+        setCurrentPair(null);
+      }
+      if (state.leaderboard) setLeaderboard(state.leaderboard);
+      if (state.results) setResults(state.results);
+    };
+
+    socket.on("split-steal-state", handleState);
+    socket.on("split-steal-timer", (t: number) => setTimer(t));
+    return () => {
+      socket.off("split-steal-state", handleState);
+      socket.off("split-steal-timer");
+    };
+  }, [socket]);
+
+  const startCountdown = () => {
+    if (socket) {
+      socket.emit("split-steal-start", sessionId);
+    }
+  };
+
+  const addPlayer = () => {
+    if (socket && newName.trim()) {
+      socket.emit("split-steal-add-player", sessionId, newName.trim());
+      setNewName("");
+    }
+  };
+
+  const removePlayer = (id: string) => {
+    if (socket) {
+      socket.emit("split-steal-remove-player", sessionId, id);
+    }
+  };
+
+  const skipRound = () => {
+    if (socket) {
+      socket.emit("split-steal-skip", sessionId);
+    }
+  };
+
+  const renderPair = () => {
+    if (!currentPair) return null;
+    return (
+      <div className="pair">
+        <span>{currentPair.nameA}</span>
+        <span>vs</span>
+        <span>{currentPair.nameB || "Sitter over"}</span>
+      </div>
+    );
+  };
+
+  const renderResults = () => {
+    if (!results) return null;
+    const [a, b] = results.pair;
+    return (
+      <div className="results">
+        <div className="result">
+          <span>{a.name}</span>
+          <span>{results.outcome}</span>
+          <span>{b ? b.name : ""}</span>
+        </div>
+      </div>
+    );
+  };
+
+  const renderLeaderboard = () => (
+    <div className="leaderboard">
+      {Object.entries(leaderboard).map(([id, stats]: any) => (
+        <div key={id} className="leaderboard-row">
+          <span>{stats.name}</span>
+          <span>{stats.sips} slurks</span>
+        </div>
+      ))}
+    </div>
+  );
+
+  return (
+    <div className="split-steal dash">
+      <button className="settings-btn" onClick={() => setShowSettings(!showSettings)}>⚙️</button>
+      {showSettings && (
+        <div className="settings-panel">
+          <h3>Innstillinger</h3>
+          <div className="add-player-row">
+            <input
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              placeholder="Navn"
+            />
+            <button onClick={addPlayer}>Legg til</button>
+          </div>
+          {participants.map((p) => (
+            <div key={p.id} className="player-row">
+              {p.name}
+              <button onClick={() => removePlayer(p.id)}>x</button>
+            </div>
+          ))}
+          <button onClick={skipRound}>Hopp over runde</button>
+        </div>
+      )}
+      {phase === "setup" && (
+        <div className="center">
+          <button onClick={startCountdown} className="btn-primary">
+            Start
+          </button>
+        </div>
+      )}
+      {phase === "countdown" && (
+        <div>
+          <h3>Time until next duel</h3>
+          <div
+            className={`countdown-text ${timer <= 10 ? "flash" : ""}`}
+          >
+            {timer}
+          </div>
+        </div>
+      )}
+      {phase === "negotiation" && currentPair && (
+        <div>
+          <p>
+            {currentPair.nameA} og {currentPair.nameB || "Sitter over"} har {timer}{" "}
+            sekunder til å diskutere hva de skal velge
+          </p>
+          {renderPair()}
+        </div>
+      )}
+      {phase === "decision" && currentPair && (
+        <div>
+          <p>
+            {currentPair.nameA} og {currentPair.nameB || "Sitter over"} må ta en
+            beslutning
+          </p>
+          {renderPair()}
+        </div>
+      )}
+      {phase === "reveal" && (
+        <div>
+          <h2>Resultater om {timer}</h2>
+          {timer === 0 && (
+            <>
+              {renderResults()}
+              {renderLeaderboard()}
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SplitOrStealDashboard;

--- a/frontend/src/components/SplitOrStealSetup.tsx
+++ b/frontend/src/components/SplitOrStealSetup.tsx
@@ -1,0 +1,79 @@
+import React, { useState } from "react";
+import { CustomSocket } from "../types/socket.types";
+import "../styles/SplitOrSteal.css";
+
+interface Props {
+  sessionId: string;
+  socket: CustomSocket | null;
+}
+
+interface Participant {
+  id: string;
+  name: string;
+}
+
+const SplitOrStealSetup: React.FC<Props> = ({ sessionId, socket }) => {
+  const [countdown, setCountdown] = useState(30);
+  const [participants, setParticipants] = useState<Participant[]>([]);
+  const [newName, setNewName] = useState("");
+
+  const addParticipant = () => {
+    if (!newName.trim()) return;
+    setParticipants((prev) => [
+      ...prev,
+      { id: Date.now().toString(36) + Math.random().toString(36).slice(2, 5), name: newName.trim() },
+    ]);
+    setNewName("");
+  };
+
+  const removeParticipant = (id: string) => {
+    setParticipants((prev) => prev.filter((p) => p.id !== id));
+  };
+
+  const startGame = () => {
+    if (socket && participants.length >= 2) {
+      socket.emit("split-steal-config", sessionId, {
+        countdownDuration: countdown,
+        participants,
+      });
+    }
+  };
+
+  return (
+    <div className="split-steal setup">
+      <h2>Split or Steal - Oppsett</h2>
+      <div className="config-row">
+        <label>Countdown (sekunder): </label>
+        <input
+          type="number"
+          value={countdown}
+          min={10}
+          max={300}
+          onChange={(e) => setCountdown(parseInt(e.target.value, 10))}
+        />
+      </div>
+      <div className="config-row">
+        <h3>Deltakere</h3>
+        <div className="add-player-row">
+          <input
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+            placeholder="Navn"
+          />
+          <button onClick={addParticipant}>Legg til</button>
+        </div>
+        {participants.map((p) => (
+          <div key={p.id} className="player-row">
+            {p.name}
+            <button onClick={() => removeParticipant(p.id)}>x</button>
+          </div>
+        ))}
+      </div>
+      <button className="btn-primary" onClick={startGame} disabled={participants.length < 2}>
+        Start
+      </button>
+    </div>
+  );
+};
+
+export default SplitOrStealSetup;

--- a/frontend/src/styles/SplitOrSteal.css
+++ b/frontend/src/styles/SplitOrSteal.css
@@ -1,0 +1,94 @@
+.split-steal {
+  color: #fff;
+  padding: 20px;
+  text-align: center;
+}
+
+.split-steal .choice-buttons button {
+  font-size: 2rem;
+  margin: 10px;
+  padding: 20px 40px;
+}
+
+.split-steal .chat-box {
+  border: 1px solid #444;
+  padding: 10px;
+  max-height: 150px;
+  overflow-y: auto;
+}
+
+.split-steal .messages {
+  text-align: left;
+  margin-bottom: 10px;
+}
+
+.split-steal .input-row {
+  display: flex;
+}
+
+.split-steal .input-row input {
+  flex: 1;
+  padding: 4px;
+  margin-right: 4px;
+}
+
+.split-steal.dash .pair {
+  margin: 5px 0;
+}
+
+.split-steal.setup {
+  max-width: 400px;
+  margin: 0 auto;
+}
+
+.split-steal .config-row {
+  margin: 10px 0;
+  text-align: left;
+}
+
+.countdown-text {
+  font-size: 4rem;
+  margin-top: 20px;
+}
+
+.countdown-text.flash {
+  color: red;
+  animation: flash 1s steps(2, start) infinite;
+}
+
+.settings-btn {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  color: #fff;
+}
+
+.settings-panel {
+  position: absolute;
+  top: 40px;
+  left: 10px;
+  background: rgba(0, 0, 0, 0.8);
+  padding: 10px;
+  border: 1px solid #444;
+  text-align: left;
+}
+
+.player-row {
+  display: flex;
+  justify-content: space-between;
+  margin: 4px 0;
+}
+
+.add-player-row {
+  display: flex;
+  margin-bottom: 6px;
+}
+
+@keyframes flash {
+  to {
+    visibility: hidden;
+  }
+}

--- a/server/index.js
+++ b/server/index.js
@@ -6,6 +6,11 @@ require("dotenv").config();
 const spotifyService = require("./spotify");
 const path = require("path");
 const sessionTimers = new Map();
+const {
+  pairPlayers,
+  calculateResults,
+  updateLeaderboard,
+} = require("../splitOrStealGameEngine");
 
 function generateSessionId(length = 6) {
   const characters = "ABCDEFGHJKLMNPQRSTUVWXYZ123456789"; // Exclude 0 and O
@@ -46,6 +51,12 @@ function sanitizeSessionForClient(session) {
   }
 
   return cleanSession;
+}
+
+function sanitizeGameState(gameState) {
+  if (!gameState) return null;
+  const { timerId, ...rest } = gameState;
+  return JSON.parse(JSON.stringify(rest));
 }
 
 // Add this function to implement session cleanup
@@ -168,6 +179,7 @@ const GAME_TYPES = {
   DRINK_OR_JUDGE: "drinkOrJudge", // Added new game type
   BEAT4BEAT: "beat4Beat", // Add this line
   NOT_ALLOWED_TO_LAUGH: "notAllowedToLaugh", // Added new game type
+  SPLIT_OR_STEAL: "splitOrSteal",
   SKJENKEHJULET: "skjenkehjulet",
 };
 
@@ -986,6 +998,15 @@ io.on("connection", (socket) => {
       };
     } else if (gameType === GAME_TYPES.SKJENKEHJULET) {
       session.gameState = { phase: "idle" };
+    } else if (gameType === GAME_TYPES.SPLIT_OR_STEAL) {
+      session.gameState = {
+        phase: "setup",
+        countdownDuration: 30,
+        timer: 0,
+        participants: [],
+        choices: {},
+        leaderboard: {},
+      };
     }
 
     // Notify all players about the game selection
@@ -2215,6 +2236,83 @@ io.on("connection", (socket) => {
     }
   });
 
+  // ----- Split or Steal events -----
+  socket.on("split-steal-config", (sessionId, config) => {
+    const session = sessions[sessionId];
+    updateSessionActivity(sessionId);
+    if (!session || session.gameType !== GAME_TYPES.SPLIT_OR_STEAL) {
+      socket.emit("error", { message: "Invalid session or game type" });
+      return;
+    }
+    if (socket.id !== session.host) {
+      socket.emit("error", { message: "Only host can configure" });
+      return;
+    }
+    session.gameState = {
+      phase: "countdown",
+      countdownDuration: config.countdownDuration || 30,
+      timer: config.countdownDuration || 30,
+      participants: config.participants || [],
+      choices: {},
+      leaderboard: {},
+    };
+    startSplitStealCountdown(sessionId);
+  });
+
+  socket.on("split-steal-start", (sessionId) => {
+    const session = sessions[sessionId];
+    if (!session || session.gameType !== GAME_TYPES.SPLIT_OR_STEAL) return;
+    if (socket.id !== session.host) return;
+    startSplitStealCountdown(sessionId);
+  });
+
+
+  socket.on("split-steal-choice", (sessionId, choice) => {
+    const session = sessions[sessionId];
+    if (!session || session.gameType !== GAME_TYPES.SPLIT_OR_STEAL) return;
+    const gs = session.gameState;
+    if (gs.currentTurn !== gs.currentPair[0].id && gs.currentTurn !== gs.currentPair[1]?.id) return;
+    gs.choices[gs.currentTurn] = choice;
+    if (gs.currentTurn === gs.currentPair[0].id && gs.currentPair[1]) {
+      gs.currentTurn = gs.currentPair[1].id;
+      gs.currentTurnName = gs.currentPair[1].name;
+      io.to(sessionId).emit(
+        "split-steal-state",
+        sanitizeGameState(gs)
+      );
+    } else {
+      startReveal(sessionId);
+    }
+  });
+
+  socket.on("split-steal-add-player", (sessionId, name) => {
+    const session = sessions[sessionId];
+    if (!session || session.gameType !== GAME_TYPES.SPLIT_OR_STEAL) return;
+    session.gameState.participants.push({ id: generateSessionId(8), name });
+    io.to(sessionId).emit(
+      "split-steal-state",
+      sanitizeGameState(session.gameState)
+    );
+  });
+
+  socket.on("split-steal-remove-player", (sessionId, id) => {
+    const session = sessions[sessionId];
+    if (!session || session.gameType !== GAME_TYPES.SPLIT_OR_STEAL) return;
+    session.gameState.participants = session.gameState.participants.filter((p) => p.id !== id);
+    delete session.gameState.leaderboard[id];
+    io.to(sessionId).emit(
+      "split-steal-state",
+      sanitizeGameState(session.gameState)
+    );
+  });
+
+  socket.on("split-steal-skip", (sessionId) => {
+    const session = sessions[sessionId];
+    if (!session || session.gameType !== GAME_TYPES.SPLIT_OR_STEAL) return;
+    clearInterval(session.gameState.timerId);
+    startSplitStealCountdown(sessionId);
+  });
+
   // End Lambo (host only)
   socket.on("end-lambo", (sessionId) => {
     const session = sessions[sessionId];
@@ -2580,6 +2678,92 @@ function moveToNextStatement(sessionId) {
     statementIndex: session.gameState.currentStatementIndex,
     totalStatements: session.gameState.availableStatements.length,
   });
+}
+
+// ----- Split or Steal basic flow -----
+function startSplitStealCountdown(sessionId) {
+  const session = sessions[sessionId];
+  if (!session) return;
+  clearInterval(session.gameState.timerId);
+  session.gameState.phase = "countdown";
+  session.gameState.timer = session.gameState.countdownDuration;
+  session.gameState.timerId = setInterval(() => {
+    const s = sessions[sessionId];
+    if (!s) return clearInterval(session.gameState.timerId);
+    s.gameState.timer -= 1;
+    io.to(sessionId).emit("split-steal-timer", s.gameState.timer);
+    if (s.gameState.timer <= 0) {
+      clearInterval(s.gameState.timerId);
+      startNegotiation(sessionId);
+    }
+  }, 1000);
+  io.to(sessionId).emit(
+    "split-steal-state",
+    sanitizeGameState(session.gameState)
+  );
+}
+
+function startNegotiation(sessionId) {
+  const session = sessions[sessionId];
+  if (!session) return;
+  const [pair] = pairPlayers(session.gameState.participants);
+  session.gameState.currentPair = pair;
+  session.gameState.choices = {};
+  session.gameState.phase = "negotiation";
+  session.gameState.timer = 60;
+  session.gameState.timerId = setInterval(() => {
+    const s = sessions[sessionId];
+    if (!s) return clearInterval(session.gameState.timerId);
+    s.gameState.timer -= 1;
+    io.to(sessionId).emit("split-steal-timer", s.gameState.timer);
+    if (s.gameState.timer <= 0) {
+      clearInterval(s.gameState.timerId);
+      s.gameState.phase = "decision";
+      s.gameState.currentTurn = pair[0].id;
+      s.gameState.currentTurnName = pair[0].name;
+      io.to(sessionId).emit(
+        "split-steal-state",
+        sanitizeGameState(s.gameState)
+      );
+    }
+  }, 1000);
+  io.to(sessionId).emit(
+    "split-steal-state",
+    sanitizeGameState(session.gameState)
+  );
+}
+
+function startReveal(sessionId) {
+  const session = sessions[sessionId];
+  if (!session) return;
+  session.gameState.phase = "reveal";
+  session.gameState.timer = 10;
+  session.gameState.timerId = setInterval(() => {
+    const s = sessions[sessionId];
+    if (!s) return clearInterval(session.gameState.timerId);
+    s.gameState.timer -= 1;
+    io.to(sessionId).emit("split-steal-timer", s.gameState.timer);
+    if (s.gameState.timer <= 0) {
+      clearInterval(s.gameState.timerId);
+      const result = calculateResults([
+        s.gameState.currentPair,
+      ], s.gameState.choices)[0];
+      s.gameState.leaderboard = updateLeaderboard(
+        s.gameState.leaderboard,
+        [result]
+      );
+      s.gameState.results = result;
+      io.to(sessionId).emit(
+        "split-steal-state",
+        sanitizeGameState(s.gameState)
+      );
+      startSplitStealCountdown(sessionId);
+    }
+  }, 1000);
+  io.to(sessionId).emit(
+    "split-steal-state",
+    sanitizeGameState(session.gameState)
+  );
 }
 
 function shuffleArray(array) {

--- a/splitOrStealGameEngine.js
+++ b/splitOrStealGameEngine.js
@@ -1,0 +1,73 @@
+// Basic game engine utilities for Split or Steal
+
+function pairPlayers(players) {
+  const shuffled = players.slice().sort(() => Math.random() - 0.5);
+  const pairs = [];
+  while (shuffled.length > 1) {
+    const a = shuffled.shift();
+    const b = shuffled.shift();
+    pairs.push([a, b]);
+  }
+  if (shuffled.length === 1) {
+    pairs.push([shuffled.shift(), null]);
+  }
+  return pairs;
+}
+
+function calculateResults(pairs, choices) {
+  return pairs.map(([a, b]) => {
+    if (!b) {
+      return { pair: [a], outcome: 'solo', sips: {} };
+    }
+    const cA = choices[a.id];
+    const cB = choices[b.id];
+    let outcome = '';
+    const sips = {};
+    if (cA === 'split' && cB === 'split') {
+      outcome = 'split-split';
+      sips[a.id] = 1;
+      sips[b.id] = 1;
+    } else if (cA === 'split' && cB === 'steal') {
+      outcome = 'split-steal';
+      sips[a.id] = 3;
+      sips[b.id] = 0;
+    } else if (cA === 'steal' && cB === 'split') {
+      outcome = 'steal-split';
+      sips[a.id] = 0;
+      sips[b.id] = 3;
+    } else {
+      outcome = 'steal-steal';
+      sips[a.id] = 2;
+      sips[b.id] = 2;
+    }
+    return { pair: [a, b], outcome, sips };
+  });
+}
+
+function updateLeaderboard(leaderboard, results) {
+  results.forEach((res) => {
+    Object.entries(res.sips).forEach(([id, s]) => {
+      if (!leaderboard[id]) {
+        const player = res.pair.find((p) => p && p.id === id);
+        leaderboard[id] = { name: player?.name || '', sips: 0, steals: 0, splits: 0 };
+      }
+      leaderboard[id].sips += s;
+    });
+    if (res.outcome === 'split-steal') {
+      const [a, b] = res.pair;
+      leaderboard[b.id].steals = (leaderboard[b.id].steals || 0) + 1;
+      leaderboard[a.id].splits = (leaderboard[a.id].splits || 0) + 1;
+    } else if (res.outcome === 'steal-split') {
+      const [a, b] = res.pair;
+      leaderboard[a.id].steals = (leaderboard[a.id].steals || 0) + 1;
+      leaderboard[b.id].splits = (leaderboard[b.id].splits || 0) + 1;
+    } else if (res.outcome === 'split-split') {
+      const [a, b] = res.pair;
+      leaderboard[a.id].splits = (leaderboard[a.id].splits || 0) + 1;
+      leaderboard[b.id].splits = (leaderboard[b.id].splits || 0) + 1;
+    }
+  });
+  return leaderboard;
+}
+
+module.exports = { pairPlayers, calculateResults, updateLeaderboard };


### PR DESCRIPTION
## Summary
- clear choice between decision turns so both players can pick
- show participants in settings menus
- display discussion/decision instructions on the dashboard

## Testing
- `npm test --prefix frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885f184c4b0832c8ad0d8815bb95f07