### PR TITLE
Filter non-players in Split or Steal

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -2051,8 +2051,16 @@ io.on("connection", (socket) => {
     const session = sessions[sessionId];
     if (!session || session.gameType !== GAME_TYPES.SPLIT_OR_STEAL) return;
 
+    // Filter out non-player entities like host and control device
+    const eligibleParticipants = session.gameState.participants.filter(
+      (p) =>
+        p &&
+        p.name &&
+        !["host", "control device"].includes(p.name.toLowerCase())
+    );
+
     // Pair players
-    const pair = pairPlayers(session.gameState.participants);
+    const pair = pairPlayers(eligibleParticipants);
 
     if (!pair) {
       // Not enough players, restart countdown


### PR DESCRIPTION
## Summary
- filter out the host and control device before pairing players in `startNegotiation`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688641c54f70832cb2408b9aa148bd64