### PR TITLE
Simplify dashboard mode

### DIFF
--- a/frontend/src/components/Game.tsx
+++ b/frontend/src/components/Game.tsx
@@ -28,6 +28,8 @@ const GAME_TYPES = {
   SPLIT_OR_STEAL: "splitOrSteal", // Add this line
 };
 
+const DASHBOARD_GAMES = [GAME_TYPES.SKJENKEHJULET, GAME_TYPES.SPLIT_OR_STEAL];
+
 const Game: React.FC = () => {
   const socket = useContext(SocketContext);
   const navigate = useNavigate();
@@ -504,8 +506,18 @@ const Game: React.FC = () => {
           sessionId={sessionData.sessionId}
           lamboVotes={lamboVotes}
           hostBackHandler={
-            sessionData.gameType === GAME_TYPES.SKJENKEHJULET
-              ? () => skjenkehjuletRef.current?.backToConfig()
+            DASHBOARD_GAMES.includes(sessionData.gameType)
+              ? () => {
+                  if (sessionData.gameType === GAME_TYPES.SKJENKEHJULET) {
+                    if (skjenkehjuletRef.current?.getPhase() === "config") {
+                      returnToLobby();
+                    } else {
+                      skjenkehjuletRef.current?.backToConfig();
+                    }
+                  } else {
+                    returnToLobby();
+                  }
+                }
               : undefined
           }
         />
@@ -521,7 +533,7 @@ const Game: React.FC = () => {
         {/* Main Menu button for host */}
         {sessionData.isHost &&
           sessionData.gameType !== GAME_TYPES.NONE &&
-          sessionData.gameType !== GAME_TYPES.SKJENKEHJULET && (
+          !DASHBOARD_GAMES.includes(sessionData.gameType) && (
             <div className="host-menu-button-container">
               <button
                 onClick={returnToLobby}
@@ -537,7 +549,7 @@ const Game: React.FC = () => {
         {!isReconnecting &&
           !error &&
           sessionData.sessionId &&
-          sessionData.gameType !== GAME_TYPES.SKJENKEHJULET && (
+          !DASHBOARD_GAMES.includes(sessionData.gameType) && (
             <div className="lambo-button-container">
               <button
                 onClick={handleLamboVote}
@@ -557,7 +569,7 @@ const Game: React.FC = () => {
           )}
 
         {/* Leave Session button */}
-        {sessionData.gameType !== GAME_TYPES.SKJENKEHJULET && (
+        {!DASHBOARD_GAMES.includes(sessionData.gameType) && (
           <div className="mobile-leave-button-container">
             <button
               onClick={confirmLeaveSession}

--- a/frontend/src/components/GameLobby.tsx
+++ b/frontend/src/components/GameLobby.tsx
@@ -74,9 +74,7 @@ const GameLobby: React.FC<GameLobbyProps> = ({
     }, 300);
   };
 
-  // Updates needed for frontend/src/components/GameLobby.tsx
-
-  // Find the gameOptions array and add the Split or Steal option:
+  // Game categories
 
   const gameOptions: GameOption[] = [
     {
@@ -109,13 +107,15 @@ const GameLobby: React.FC<GameLobbyProps> = ({
       icon: "😂",
       color: "#6200ea",
     },
+  ];
+
+  const dashboardGames: GameOption[] = [
     {
       id: "skjenkehjulet",
       name: "Skjenkehjulet",
       icon: "🍻",
       color: "#ff9800",
     },
-    // Add this new option:
     {
       id: "splitOrSteal",
       name: "Split or Steal",
@@ -220,24 +220,50 @@ const GameLobby: React.FC<GameLobbyProps> = ({
                     </span>
                   )}
                 </h2>
-                <div className="games-grid">
-                  {gameOptions.map((game: GameOption) => (
-                    <button
-                      key={game.id}
-                      onClick={() => handleGameSelect(game.id)}
-                      className={`game-button ${
-                        selectedGame === game.id ? "selected" : ""
-                      } ${!isHost ? "non-host" : ""}`}
-                      style={{
-                        backgroundColor: game.color + "15", // Add transparency to color
-                        borderColor: game.color,
-                      }}
-                      disabled={!isHost}
-                    >
-                      <span className="game-icon">{game.icon}</span>
-                      <span className="game-name">{game.name}</span>
-                    </button>
-                  ))}
+                <div className="games-section">
+                  <h3 className="games-section-title">Party Games</h3>
+                  <div className="games-grid">
+                    {gameOptions.map((game: GameOption) => (
+                      <button
+                        key={game.id}
+                        onClick={() => handleGameSelect(game.id)}
+                        className={`game-button ${
+                          selectedGame === game.id ? "selected" : ""
+                        } ${!isHost ? "non-host" : ""}`}
+                        style={{
+                          backgroundColor: game.color + "15",
+                          borderColor: game.color,
+                        }}
+                        disabled={!isHost}
+                      >
+                        <span className="game-icon">{game.icon}</span>
+                        <span className="game-name">{game.name}</span>
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="games-section">
+                  <h3 className="games-section-title">Dashboard Games</h3>
+                  <div className="games-grid">
+                    {dashboardGames.map((game: GameOption) => (
+                      <button
+                        key={game.id}
+                        onClick={() => handleGameSelect(game.id)}
+                        className={`game-button ${
+                          selectedGame === game.id ? "selected" : ""
+                        } ${!isHost ? "non-host" : ""}`}
+                        style={{
+                          backgroundColor: game.color + "15",
+                          borderColor: game.color,
+                        }}
+                        disabled={!isHost}
+                      >
+                        <span className="game-icon">{game.icon}</span>
+                        <span className="game-name">{game.name}</span>
+                      </button>
+                    ))}
+                  </div>
                 </div>
 
                 {!isHost && (

--- a/frontend/src/components/Skjenkehjulet.tsx
+++ b/frontend/src/components/Skjenkehjulet.tsx
@@ -20,6 +20,7 @@ declare global {
 
 export interface SkjenkehjuletHandle {
   backToConfig: () => void;
+  getPhase: () => string;
 }
 
 // Helper function to shuffle an array
@@ -153,6 +154,7 @@ const Skjenkehjulet = forwardRef<SkjenkehjuletHandle>((props, ref) => {
 
   useImperativeHandle(ref, () => ({
     backToConfig,
+    getPhase: () => phase,
   }));
 
   // Shuffle categories when starting a new game

--- a/frontend/src/components/SplitOrStealController.tsx
+++ b/frontend/src/components/SplitOrStealController.tsx
@@ -27,9 +27,6 @@ const SplitOrStealController: React.FC<SplitOrStealControllerProps> = ({
   const [currentPhase, setCurrentPhase] = useState<string>("countdown");
   const [currentPair, setCurrentPair] = useState<any>(null);
   const [results, setResults] = useState<any>(null);
-  const [leaderboard, setLeaderboard] = useState<
-    Array<{ id: string; name: string; points: number }>
-  >([]);
   const [myChoice, setMyChoice] = useState<string | null>(null);
   const [currentPlayer, setCurrentPlayer] = useState<string | null>(null);
   const [showSettings, setShowSettings] = useState<boolean>(false);
@@ -46,7 +43,6 @@ const SplitOrStealController: React.FC<SplitOrStealControllerProps> = ({
       setCurrentPhase(gameState.phase || "countdown");
       setCurrentPair(gameState.currentPair || null);
       setResults(gameState.results || null);
-      setLeaderboard(gameState.leaderboard || []);
       setCurrentPlayer(gameState.currentPlayer || null);
       setParticipants(gameState.participants || []);
 
@@ -79,9 +75,6 @@ const SplitOrStealController: React.FC<SplitOrStealControllerProps> = ({
         setResults(data.results);
       }
 
-      if (data.leaderboard) {
-        setLeaderboard(data.leaderboard);
-      }
 
       if (data.participants) {
         setParticipants(data.participants);
@@ -140,11 +133,6 @@ const SplitOrStealController: React.FC<SplitOrStealControllerProps> = ({
   };
 
 
-  const getMyPointsFromLeaderboard = (): number => {
-    if (!socket?.id) return 0;
-    const myEntry = leaderboard.find((entry) => entry.id === socket.id);
-    return myEntry ? myEntry.points : 0;
-  };
 
   const renderCountdownPhase = () => (
     <div className="controller-container">
@@ -412,21 +400,6 @@ const SplitOrStealController: React.FC<SplitOrStealControllerProps> = ({
       {currentPhase === "negotiation" && renderNegotiationPhase()}
       {currentPhase === "decision" && renderDecisionPhase()}
       {currentPhase === "reveal" && renderRevealPhase()}
-
-      {/* Always show personal score */}
-      <div
-        style={{
-          position: "fixed",
-          top: "20px",
-          left: "20px",
-          background: "rgba(0,0,0,0.3)",
-          padding: "10px 15px",
-          borderRadius: "8px",
-          backdropFilter: "blur(10px)",
-        }}
-      >
-        <strong>Your Score: {getMyPointsFromLeaderboard()} pts</strong>
-      </div>
 
       {renderSettingsModal()}
     </div>

--- a/frontend/src/components/SplitOrStealDashboard.tsx
+++ b/frontend/src/components/SplitOrStealDashboard.tsx
@@ -27,9 +27,6 @@ const SplitOrStealDashboard: React.FC<SplitOrStealDashboardProps> = ({
   const [currentPhase, setCurrentPhase] = useState<string>("countdown");
   const [currentPair, setCurrentPair] = useState<any>(null);
   const [results, setResults] = useState<any>(null);
-  const [leaderboard, setLeaderboard] = useState<
-    Array<{ id: string; name: string; points: number }>
-  >([]);
   const [showSettings, setShowSettings] = useState<boolean>(false);
   const [participants, setParticipants] = useState<
     Array<{ id: string; name: string }>
@@ -43,7 +40,6 @@ const SplitOrStealDashboard: React.FC<SplitOrStealDashboardProps> = ({
       setCurrentPhase(gameState.phase || "countdown");
       setCurrentPair(gameState.currentPair || null);
       setResults(gameState.results || null);
-      setLeaderboard(gameState.leaderboard || []);
       setParticipants(gameState.participants || []);
     }
   }, [gameState]);
@@ -68,9 +64,6 @@ const SplitOrStealDashboard: React.FC<SplitOrStealDashboardProps> = ({
         setResults(data.results);
       }
 
-      if (data.leaderboard) {
-        setLeaderboard(data.leaderboard);
-      }
 
       if (data.participants) {
         setParticipants(data.participants);
@@ -341,27 +334,7 @@ const SplitOrStealDashboard: React.FC<SplitOrStealDashboardProps> = ({
         {currentPhase === "decision" && renderDecisionPhase()}
         {currentPhase === "reveal" && renderRevealPhase()}
 
-        {leaderboard.length > 0 && (
-          <div className="leaderboard">
-            <h3>Leaderboard</h3>
-            <div className="leaderboard-list">
-              {leaderboard.map((entry, index) => (
-                <div
-                  key={entry.id}
-                  className={`leaderboard-item ${
-                    index === 0 ? "first-place" : ""
-                  }`}
-                >
-                  <span className="player-rank">#{index + 1}</span>
-                  <div className="player-info">
-                    <span>{entry.name}</span>
-                  </div>
-                  <span className="player-score">{entry.points} pts</span>
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
+        {/* leaderboard removed for dashboard version */}
       </div>
 
       {renderSettingsModal()}

--- a/frontend/src/styles/GameLobby.css
+++ b/frontend/src/styles/GameLobby.css
@@ -260,6 +260,17 @@
   gap: 1rem;
 }
 
+.games-section {
+  margin-bottom: 2rem;
+}
+
+.games-section-title {
+  margin: 0 0 0.5rem 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.7);
+}
+
 .game-button {
   background-color: rgba(255, 255, 255, 0.05);
   color: white;


### PR DESCRIPTION
## Summary
- remove personal score panel from SplitOrSteal controller
- drop leaderboard from SplitOrSteal dashboard
- categorize dashboard games in lobby and list Split or Steal there
- hide mobile controls for dashboard games and provide back arrow
- expose Skjenkehjulet phase for back arrow logic

## Testing
- `npm test --prefix frontend` *(fails: react-scripts not found)*
- `npm run build --prefix frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68865e39c4d4832ca804ca5dbbf37032