### PR TITLE
Update Split or Steal results view

### DIFF
--- a/frontend/src/components/SplitOrStealDashboard.tsx
+++ b/frontend/src/components/SplitOrStealDashboard.tsx
@@ -162,7 +162,6 @@ const SplitOrStealDashboard: React.FC<SplitOrStealDashboardProps> = ({
   );
 
   const renderRevealPhase = () => {
-    // Get player choices (convert to uppercase to match button rendering)
     const player1Choice =
       results?.choices?.[currentPair?.player1?.id]?.toUpperCase();
     const player2Choice =
@@ -171,86 +170,64 @@ const SplitOrStealDashboard: React.FC<SplitOrStealDashboardProps> = ({
     return (
       <div className="phase-container">
         <style>{`
-         .reveal-animation-container {
-          position: relative;
-          width: 100vw; /* Changed: Use viewport width */
-          left: 50%;
-          right: 50%;
-          margin-left: -50vw;
-          margin-right: -50vw;
-          height: 400px;
-          display: flex;
-          justify-content: center;
-          align-items: center;
-          overflow: hidden;
-          background: radial-gradient(ellipse at center, #1a1a2e 0%, #0f0f1e 100%);
-          /* border-radius and margin removed to be flush with edges */
-        }
-  
+          .reveal-animation-container {
+            position: relative;
+            width: 100vw;
+            left: 50%;
+            right: 50%;
+            margin-left: -50vw;
+            margin-right: -50vw;
+            height: 400px;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            overflow: hidden;
+            background: radial-gradient(ellipse at center, #1a1a2e 0%, #0f0f1e 100%);
+          }
+
           .reveal-red-bar {
             position: absolute;
             height: 120px;
             background: linear-gradient(90deg, #DC143C 0%, #FF6B6B 50%, #DC143C 100%);
-            box-shadow: 
-              0 0 30px rgba(220, 20, 60, 0.8),
-              0 0 60px rgba(220, 20, 60, 0.5),
-              inset 0 2px 4px rgba(255, 255, 255, 0.3);
+            box-shadow: 0 0 30px rgba(220,20,60,0.8), 0 0 60px rgba(220,20,60,0.5), inset 0 2px 4px rgba(255,255,255,0.3);
             z-index: 10;
           }
-  
+
           .reveal-red-bar-left {
             left: -50%;
             width: 50%;
             animation: revealSlideInLeft 1.5s ease-out forwards;
           }
-  
+
           .reveal-red-bar-right {
             right: -50%;
             width: 50%;
             animation: revealSlideInRight 1.5s ease-out forwards;
           }
-  
+
           @keyframes revealSlideInLeft {
-            to {
-              left: 0;
-              width: calc(20% + 75px);
-            }
+            to { left: 0; width: calc(20% + 75px); }
           }
-  
+
           @keyframes revealSlideInRight {
-            to {
-              right: 0;
-              width: calc(20% + 75px);
-            }
+            to { right: 0; width: calc(20% + 75px); }
           }
-  
+
           .reveal-button-container {
             position: absolute;
             z-index: 20;
-            opacity: 0;
-            animation: revealFadeIn 0.5s ease-out 1.5s forwards;
+            opacity: 1;
           }
-  
-          .reveal-button-left {
-            left: 20%;
-          }
-  
-          .reveal-button-right {
-            right: 20%;
-          }
-  
-          @keyframes revealFadeIn {
-            to {
-              opacity: 1;
-            }
-          }
-  
+
+          .reveal-button-left { left: 20%; }
+          .reveal-button-right { right: 20%; }
+
           .reveal-button-svg {
             width: 150px;
             height: 150px;
-            filter: drop-shadow(0 0 20px rgba(0, 0, 0, 0.8));
+            filter: drop-shadow(0 0 20px rgba(0,0,0,0.8));
           }
-  
+
           .player-name-label {
             position: absolute;
             bottom: -40px;
@@ -261,403 +238,350 @@ const SplitOrStealDashboard: React.FC<SplitOrStealDashboardProps> = ({
             font-weight: bold;
             text-align: center;
             width: 200px;
-            text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.8);
-          }
-  
-          .reveal-results-overlay {
-            position: absolute;
-            top: 20px;
-            left: 50%;
-            transform: translateX(-50%);
-            text-align: center;
-            color: white;
-            z-index: 30;
-            opacity: 0;
-            animation: revealFadeIn 0.5s ease-out 2s forwards;
-          }
-  
-          .reveal-outcome-message {
-            font-size: 24px;
-            font-weight: bold;
-            margin: 20px 0;
-            text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.8);
-          }
-  
-          .reveal-drinking-penalty {
-            background: rgba(0, 0, 0, 0.5);
-            padding: 15px;
-            border-radius: 10px;
-            margin-top: 20px;
-          }
-  
-          .reveal-penalty-title {
-            font-size: 20px;
-            margin-bottom: 10px;
+            text-shadow: 2px 2px 4px rgba(0,0,0,0.8);
           }
         `}</style>
 
-        <div className="reveal-results">
-          <h3 style={{ marginTop: 0 }}>Results</h3>
+        {results &&
+          currentPair &&
+          currentPair.player1 &&
+          currentPair.player2 && (
+            <div className="reveal-animation-container">
+              <div className="reveal-red-bar reveal-red-bar-left"></div>
+              <div className="reveal-red-bar reveal-red-bar-right"></div>
 
-          {results &&
-            currentPair &&
-            currentPair.player1 &&
-            currentPair.player2 && (
-              <div className="reveal-animation-container">
-                {/* Red bars */}
-                <div className="reveal-red-bar reveal-red-bar-left"></div>
-                <div className="reveal-red-bar reveal-red-bar-right"></div>
-
-                {/* Player 1 button (left side) */}
-                <div className="reveal-button-container reveal-button-left">
-                  {player1Choice === "SPLIT" ? (
-                    // SPLIT button SVG
-                    <svg
-                      className="reveal-button-svg"
-                      viewBox="0 0 200 200"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <defs>
-                        <radialGradient id="yellowGradient1">
-                          <stop offset="0%" stopColor="#FFE066" />
-                          <stop offset="70%" stopColor="#FFA500" />
-                          <stop offset="100%" stopColor="#FF8C00" />
-                        </radialGradient>
-                      </defs>
-                      <g transform="translate(100, 100)">
-                        <circle
-                          r="70"
-                          fill="none"
-                          stroke="#C0C0C0"
-                          strokeWidth="5"
-                        />
-                        <circle r="68" fill="white" />
-                        <circle r="65" fill="url(#yellowGradient1)" />
-                        <circle
-                          r="60"
-                          fill="none"
-                          stroke="rgba(255,255,255,0.2)"
-                          strokeWidth="1"
-                        />
-                        <circle
-                          r="55"
-                          fill="none"
-                          stroke="rgba(255,255,255,0.15)"
-                          strokeWidth="1"
-                        />
-                        <circle
-                          r="50"
-                          fill="none"
-                          stroke="rgba(255,255,255,0.1)"
-                          strokeWidth="1"
-                        />
-                        <circle
-                          r="45"
-                          fill="none"
-                          stroke="rgba(255,255,255,0.05)"
-                          strokeWidth="1"
-                        />
-                        <text
-                          y="10"
-                          textAnchor="middle"
-                          fontFamily="Arial Black"
-                          fontSize="40"
-                          fontWeight="900"
-                          letterSpacing="-2"
-                          fill="#FFF"
-                        >
-                          SPLIT
-                        </text>
-                        <text
-                          y="10"
-                          textAnchor="middle"
-                          fontFamily="Arial Black"
-                          fontSize="40"
-                          fontWeight="900"
-                          letterSpacing="-2"
-                          fill="none"
-                          stroke="#FF8C00"
-                          strokeWidth="3"
-                        >
-                          SPLIT
-                        </text>
-                      </g>
-                    </svg>
-                  ) : (
-                    // STEAL button SVG
-                    <svg
-                      className="reveal-button-svg"
-                      viewBox="0 0 200 200"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <defs>
-                        <radialGradient id="redGradient1">
-                          <stop offset="0%" stopColor="#FF6B6B" />
-                          <stop offset="70%" stopColor="#DC143C" />
-                          <stop offset="100%" stopColor="#8B0000" />
-                        </radialGradient>
-                      </defs>
-                      <g transform="translate(100, 100)">
-                        <circle
-                          r="70"
-                          fill="none"
-                          stroke="#C0C0C0"
-                          strokeWidth="5"
-                        />
-                        <circle r="68" fill="white" />
-                        <circle r="65" fill="url(#redGradient1)" />
-                        <circle
-                          r="60"
-                          fill="none"
-                          stroke="rgba(255,255,255,0.2)"
-                          strokeWidth="1"
-                        />
-                        <circle
-                          r="55"
-                          fill="none"
-                          stroke="rgba(255,255,255,0.15)"
-                          strokeWidth="1"
-                        />
-                        <circle
-                          r="50"
-                          fill="none"
-                          stroke="rgba(255,255,255,0.1)"
-                          strokeWidth="1"
-                        />
-                        <circle
-                          r="45"
-                          fill="none"
-                          stroke="rgba(255,255,255,0.05)"
-                          strokeWidth="1"
-                        />
-                        <text
-                          y="10"
-                          textAnchor="middle"
-                          fontFamily="Arial Black"
-                          fontSize="40"
-                          fontWeight="900"
-                          letterSpacing="-2"
-                          fill="#FFF"
-                        >
-                          STEAL
-                        </text>
-                        <text
-                          y="10"
-                          textAnchor="middle"
-                          fontFamily="Arial Black"
-                          fontSize="40"
-                          fontWeight="900"
-                          letterSpacing="-2"
-                          fill="none"
-                          stroke="#8B0000"
-                          strokeWidth="3"
-                        >
-                          STEAL
-                        </text>
-                      </g>
-                    </svg>
-                  )}
-                  <div className="player-name-label">
-                    {currentPair.player1.name || "Player 1"}
-                  </div>
-                </div>
-
-                {/* Player 2 button (right side) */}
-                <div className="reveal-button-container reveal-button-right">
-                  {player2Choice === "SPLIT" ? (
-                    // SPLIT button SVG
-                    <svg
-                      className="reveal-button-svg"
-                      viewBox="0 0 200 200"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <defs>
-                        <radialGradient id="yellowGradient2">
-                          <stop offset="0%" stopColor="#FFE066" />
-                          <stop offset="70%" stopColor="#FFA500" />
-                          <stop offset="100%" stopColor="#FF8C00" />
-                        </radialGradient>
-                      </defs>
-                      <g transform="translate(100, 100)">
-                        <circle
-                          r="70"
-                          fill="none"
-                          stroke="#C0C0C0"
-                          strokeWidth="5"
-                        />
-                        <circle r="68" fill="white" />
-                        <circle r="65" fill="url(#yellowGradient2)" />
-                        <circle
-                          r="60"
-                          fill="none"
-                          stroke="rgba(255,255,255,0.2)"
-                          strokeWidth="1"
-                        />
-                        <circle
-                          r="55"
-                          fill="none"
-                          stroke="rgba(255,255,255,0.15)"
-                          strokeWidth="1"
-                        />
-                        <circle
-                          r="50"
-                          fill="none"
-                          stroke="rgba(255,255,255,0.1)"
-                          strokeWidth="1"
-                        />
-                        <circle
-                          r="45"
-                          fill="none"
-                          stroke="rgba(255,255,255,0.05)"
-                          strokeWidth="1"
-                        />
-                        <text
-                          y="10"
-                          textAnchor="middle"
-                          fontFamily="Arial Black"
-                          fontSize="40"
-                          fontWeight="900"
-                          letterSpacing="-2"
-                          fill="#FFF"
-                        >
-                          SPLIT
-                        </text>
-                        <text
-                          y="10"
-                          textAnchor="middle"
-                          fontFamily="Arial Black"
-                          fontSize="40"
-                          fontWeight="900"
-                          letterSpacing="-2"
-                          fill="none"
-                          stroke="#FF8C00"
-                          strokeWidth="3"
-                        >
-                          SPLIT
-                        </text>
-                      </g>
-                    </svg>
-                  ) : (
-                    // STEAL button SVG
-                    <svg
-                      className="reveal-button-svg"
-                      viewBox="0 0 200 200"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <defs>
-                        <radialGradient id="redGradient2">
-                          <stop offset="0%" stopColor="#FF6B6B" />
-                          <stop offset="70%" stopColor="#DC143C" />
-                          <stop offset="100%" stopColor="#8B0000" />
-                        </radialGradient>
-                      </defs>
-                      <g transform="translate(100, 100)">
-                        <circle
-                          r="70"
-                          fill="none"
-                          stroke="#C0C0C0"
-                          strokeWidth="5"
-                        />
-                        <circle r="68" fill="white" />
-                        <circle r="65" fill="url(#redGradient2)" />
-                        <circle
-                          r="60"
-                          fill="none"
-                          stroke="rgba(255,255,255,0.2)"
-                          strokeWidth="1"
-                        />
-                        <circle
-                          r="55"
-                          fill="none"
-                          stroke="rgba(255,255,255,0.15)"
-                          strokeWidth="1"
-                        />
-                        <circle
-                          r="50"
-                          fill="none"
-                          stroke="rgba(255,255,255,0.1)"
-                          strokeWidth="1"
-                        />
-                        <circle
-                          r="45"
-                          fill="none"
-                          stroke="rgba(255,255,255,0.05)"
-                          strokeWidth="1"
-                        />
-                        <text
-                          y="10"
-                          textAnchor="middle"
-                          fontFamily="Arial Black"
-                          fontSize="40"
-                          fontWeight="900"
-                          letterSpacing="-2"
-                          fill="#FFF"
-                        >
-                          STEAL
-                        </text>
-                        <text
-                          y="10"
-                          textAnchor="middle"
-                          fontFamily="Arial Black"
-                          fontSize="40"
-                          fontWeight="900"
-                          letterSpacing="-2"
-                          fill="none"
-                          stroke="#8B0000"
-                          strokeWidth="3"
-                        >
-                          STEAL
-                        </text>
-                      </g>
-                    </svg>
-                  )}
-                  <div className="player-name-label">
-                    {currentPair.player2.name || "Player 2"}
-                  </div>
-                </div>
-
-                {/* Results overlay */}
-                <div className="reveal-results-overlay">
-                  <div className="reveal-outcome-message">
-                    {results.outcomeMessage || "No outcome message"}
-                  </div>
-
-                  {results.drinkingPenalty &&
-                    results.drinkingPenalty.length > 0 && (
-                      <div className="reveal-drinking-penalty">
-                        <div className="reveal-penalty-title">
-                          🍺 Drinking Penalty:
-                        </div>
-                        {results.drinkingPenalty.map((playerId: string) => {
-                          const player =
-                            participants.find((p) => p.id === playerId) ||
-                            (currentPair.player1.id === playerId
-                              ? currentPair.player1
-                              : currentPair.player2);
-                          return (
-                            <div key={playerId} style={{ marginTop: "0.5rem" }}>
-                              <strong>
-                                {player?.name || "Unknown Player"}
-                              </strong>{" "}
-                              must drink!
-                            </div>
-                          );
-                        })}
-                      </div>
-                    )}
+              <div className="reveal-button-container reveal-button-left">
+                {player1Choice === "SPLIT" ? (
+                  <svg
+                    className="reveal-button-svg"
+                    viewBox="0 0 200 200"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <defs>
+                      <radialGradient id="yellowGradient1">
+                        <stop offset="0%" stopColor="#FFE066" />
+                        <stop offset="70%" stopColor="#FFA500" />
+                        <stop offset="100%" stopColor="#FF8C00" />
+                      </radialGradient>
+                    </defs>
+                    <g transform="translate(100, 100)">
+                      <circle
+                        r="70"
+                        fill="none"
+                        stroke="#C0C0C0"
+                        strokeWidth="5"
+                      />
+                      <circle r="68" fill="white" />
+                      <circle r="65" fill="url(#yellowGradient1)" />
+                      <circle
+                        r="60"
+                        fill="none"
+                        stroke="rgba(255,255,255,0.2)"
+                        strokeWidth="1"
+                      />
+                      <circle
+                        r="55"
+                        fill="none"
+                        stroke="rgba(255,255,255,0.15)"
+                        strokeWidth="1"
+                      />
+                      <circle
+                        r="50"
+                        fill="none"
+                        stroke="rgba(255,255,255,0.1)"
+                        strokeWidth="1"
+                      />
+                      <circle
+                        r="45"
+                        fill="none"
+                        stroke="rgba(255,255,255,0.05)"
+                        strokeWidth="1"
+                      />
+                      <text
+                        y="10"
+                        textAnchor="middle"
+                        fontFamily="Arial Black"
+                        fontSize="40"
+                        fontWeight="900"
+                        letterSpacing="-2"
+                        fill="#FFF"
+                      >
+                        SPLIT
+                      </text>
+                      <text
+                        y="10"
+                        textAnchor="middle"
+                        fontFamily="Arial Black"
+                        fontSize="40"
+                        fontWeight="900"
+                        letterSpacing="-2"
+                        fill="none"
+                        stroke="#FF8C00"
+                        strokeWidth="3"
+                      >
+                        SPLIT
+                      </text>
+                    </g>
+                  </svg>
+                ) : (
+                  <svg
+                    className="reveal-button-svg"
+                    viewBox="0 0 200 200"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <defs>
+                      <radialGradient id="redGradient1">
+                        <stop offset="0%" stopColor="#FF6B6B" />
+                        <stop offset="70%" stopColor="#DC143C" />
+                        <stop offset="100%" stopColor="#8B0000" />
+                      </radialGradient>
+                    </defs>
+                    <g transform="translate(100, 100)">
+                      <circle
+                        r="70"
+                        fill="none"
+                        stroke="#C0C0C0"
+                        strokeWidth="5"
+                      />
+                      <circle r="68" fill="white" />
+                      <circle r="65" fill="url(#redGradient1)" />
+                      <circle
+                        r="60"
+                        fill="none"
+                        stroke="rgba(255,255,255,0.2)"
+                        strokeWidth="1"
+                      />
+                      <circle
+                        r="55"
+                        fill="none"
+                        stroke="rgba(255,255,255,0.15)"
+                        strokeWidth="1"
+                      />
+                      <circle
+                        r="50"
+                        fill="none"
+                        stroke="rgba(255,255,255,0.1)"
+                        strokeWidth="1"
+                      />
+                      <circle
+                        r="45"
+                        fill="none"
+                        stroke="rgba(255,255,255,0.05)"
+                        strokeWidth="1"
+                      />
+                      <text
+                        y="10"
+                        textAnchor="middle"
+                        fontFamily="Arial Black"
+                        fontSize="40"
+                        fontWeight="900"
+                        letterSpacing="-2"
+                        fill="#FFF"
+                      >
+                        STEAL
+                      </text>
+                      <text
+                        y="10"
+                        textAnchor="middle"
+                        fontFamily="Arial Black"
+                        fontSize="40"
+                        fontWeight="900"
+                        letterSpacing="-2"
+                        fill="none"
+                        stroke="#8B0000"
+                        strokeWidth="3"
+                      >
+                        STEAL
+                      </text>
+                    </g>
+                  </svg>
+                )}
+                <div className="player-name-label">
+                  {currentPair.player1.name || "Player 1"}
                 </div>
               </div>
-            )}
 
-          <div className="countdown-display" style={{ marginTop: "20px" }}>
-            {formatTime(timeLeft)}
+              <div className="reveal-button-container reveal-button-right">
+                {player2Choice === "SPLIT" ? (
+                  <svg
+                    className="reveal-button-svg"
+                    viewBox="0 0 200 200"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <defs>
+                      <radialGradient id="yellowGradient2">
+                        <stop offset="0%" stopColor="#FFE066" />
+                        <stop offset="70%" stopColor="#FFA500" />
+                        <stop offset="100%" stopColor="#FF8C00" />
+                      </radialGradient>
+                    </defs>
+                    <g transform="translate(100, 100)">
+                      <circle
+                        r="70"
+                        fill="none"
+                        stroke="#C0C0C0"
+                        strokeWidth="5"
+                      />
+                      <circle r="68" fill="white" />
+                      <circle r="65" fill="url(#yellowGradient2)" />
+                      <circle
+                        r="60"
+                        fill="none"
+                        stroke="rgba(255,255,255,0.2)"
+                        strokeWidth="1"
+                      />
+                      <circle
+                        r="55"
+                        fill="none"
+                        stroke="rgba(255,255,255,0.15)"
+                        strokeWidth="1"
+                      />
+                      <circle
+                        r="50"
+                        fill="none"
+                        stroke="rgba(255,255,255,0.1)"
+                        strokeWidth="1"
+                      />
+                      <circle
+                        r="45"
+                        fill="none"
+                        stroke="rgba(255,255,255,0.05)"
+                        strokeWidth="1"
+                      />
+                      <text
+                        y="10"
+                        textAnchor="middle"
+                        fontFamily="Arial Black"
+                        fontSize="40"
+                        fontWeight="900"
+                        letterSpacing="-2"
+                        fill="#FFF"
+                      >
+                        SPLIT
+                      </text>
+                      <text
+                        y="10"
+                        textAnchor="middle"
+                        fontFamily="Arial Black"
+                        fontSize="40"
+                        fontWeight="900"
+                        letterSpacing="-2"
+                        fill="none"
+                        stroke="#FF8C00"
+                        strokeWidth="3"
+                      >
+                        SPLIT
+                      </text>
+                    </g>
+                  </svg>
+                ) : (
+                  <svg
+                    className="reveal-button-svg"
+                    viewBox="0 0 200 200"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <defs>
+                      <radialGradient id="redGradient2">
+                        <stop offset="0%" stopColor="#FF6B6B" />
+                        <stop offset="70%" stopColor="#DC143C" />
+                        <stop offset="100%" stopColor="#8B0000" />
+                      </radialGradient>
+                    </defs>
+                    <g transform="translate(100, 100)">
+                      <circle
+                        r="70"
+                        fill="none"
+                        stroke="#C0C0C0"
+                        strokeWidth="5"
+                      />
+                      <circle r="68" fill="white" />
+                      <circle r="65" fill="url(#redGradient2)" />
+                      <circle
+                        r="60"
+                        fill="none"
+                        stroke="rgba(255,255,255,0.2)"
+                        strokeWidth="1"
+                      />
+                      <circle
+                        r="55"
+                        fill="none"
+                        stroke="rgba(255,255,255,0.15)"
+                        strokeWidth="1"
+                      />
+                      <circle
+                        r="50"
+                        fill="none"
+                        stroke="rgba(255,255,255,0.1)"
+                        strokeWidth="1"
+                      />
+                      <circle
+                        r="45"
+                        fill="none"
+                        stroke="rgba(255,255,255,0.05)"
+                        strokeWidth="1"
+                      />
+                      <text
+                        y="10"
+                        textAnchor="middle"
+                        fontFamily="Arial Black"
+                        fontSize="40"
+                        fontWeight="900"
+                        letterSpacing="-2"
+                        fill="#FFF"
+                      >
+                        STEAL
+                      </text>
+                      <text
+                        y="10"
+                        textAnchor="middle"
+                        fontFamily="Arial Black"
+                        fontSize="40"
+                        fontWeight="900"
+                        letterSpacing="-2"
+                        fill="none"
+                        stroke="#8B0000"
+                        strokeWidth="3"
+                      >
+                        STEAL
+                      </text>
+                    </g>
+                  </svg>
+                )}
+                <div className="player-name-label">
+                  {currentPair.player2.name || "Player 2"}
+                </div>
+              </div>
+            </div>
+          )}
+
+        {results && (
+          <div className="reveal-sips-screen">
+            <div className="reveal-sips-players">
+              <div className="reveal-sip-player">
+                <div className="reveal-sip-name">
+                  {currentPair.player1.name || "Player 1"}
+                </div>
+                <div className="reveal-sip-amount">
+                  {results.player1Points} sips
+                </div>
+              </div>
+              <div className="reveal-sip-player">
+                <div className="reveal-sip-name">
+                  {currentPair.player2.name || "Player 2"}
+                </div>
+                <div className="reveal-sip-amount">
+                  {results.player2Points} sips
+                </div>
+              </div>
+            </div>
+            <div className="reveal-next-round">
+              {timeLeft} seconds until next round
+            </div>
           </div>
-          <p>Next round starting in {timeLeft} seconds...</p>
-        </div>
+        )}
       </div>
     );
   };
-
   const renderSettingsModal = () => {
     if (!showSettings) return null;
 

--- a/frontend/src/styles/Game.css
+++ b/frontend/src/styles/Game.css
@@ -9,6 +9,8 @@
 
 .game-content {
   flex: 1;
+  display: flex;
+  flex-direction: column;
   /* Add padding to prevent content being hidden behind buttons */
   padding-bottom: 80px;
 }
@@ -369,6 +371,8 @@
 
   /* Ensure content isn't hidden behind the button bar */
   .game-content {
+    display: flex;
+    flex-direction: column;
     padding-bottom: 80px;
   }
 
@@ -550,6 +554,8 @@
 
   /* Ensure content isn't hidden behind the button bar */
   .game-content {
+    display: flex;
+    flex-direction: column;
     padding-bottom: 70px;
   }
 }

--- a/frontend/src/styles/SplitOrSteal.css
+++ b/frontend/src/styles/SplitOrSteal.css
@@ -1,6 +1,7 @@
 /* SplitOrSteal.css */
 
 .split-or-steal {
+  flex: 1;
   min-height: 100vh;
   background: linear-gradient(135deg, #1e3c72 0%, #2a5298 100%);
   color: white;
@@ -514,6 +515,49 @@
 
 .skip-round:hover {
   background: #f39c12;
+}
+
+/* Reveal sips screen */
+.reveal-sips-screen {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: #2a5298;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  color: #fff;
+  z-index: 40;
+  opacity: 0;
+  animation: revealFadeIn 0.5s ease-out 2s forwards;
+}
+
+.reveal-sips-players {
+  width: 100%;
+  display: flex;
+  justify-content: space-around;
+  margin-bottom: 2rem;
+}
+
+.reveal-sip-player {
+  text-align: center;
+}
+
+.reveal-sip-name {
+  font-size: 2rem;
+  font-weight: bold;
+}
+
+.reveal-sip-amount {
+  font-size: 3rem;
+  margin-top: 0.5rem;
+}
+
+.reveal-next-round {
+  font-size: 1.2rem;
 }
 
 /* Mobile Responsiveness */


### PR DESCRIPTION
## Summary
- fill game-content with flex layout
- let split-or-steal container take full height
- add result "sips" overlay
- remove old outcome message
- keep player names visible during reveal

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6887ff72b9d8832ca28c0863ff6c7ec3