### PR TITLE
Rename game to Cheers Or Tears

### DIFF
--- a/frontend/src/components/Game.tsx
+++ b/frontend/src/components/Game.tsx
@@ -11,7 +11,7 @@ import Beat4Beat from "./Beat4Beat";
 import LamboScreen from "./LamboScreen"; // Import the new LamboScreen component
 import NotAllowedToLaugh from "./NotAllowedToLaugh";
 import Skjenkehjulet, { SkjenkehjuletHandle } from "./Skjenkehjulet";
-// 1. First, add the import for Split or Steal components at the top:
+// 1. First, add the import for Cheers Or Tears components at the top:
 import SplitOrStealSetup from "./SplitOrStealSetup";
 import SplitOrStealDashboard from "./SplitOrStealDashboard";
 import SplitOrStealController from "./SplitOrStealController";

--- a/frontend/src/components/GameLobby.tsx
+++ b/frontend/src/components/GameLobby.tsx
@@ -118,7 +118,7 @@ const GameLobby: React.FC<GameLobbyProps> = ({
     },
     {
       id: "splitOrSteal",
-      name: "Split or Steal",
+      name: "Cheers Or Tears",
       icon: "💰",
       color: "#f39c12",
     },

--- a/frontend/src/components/SplitOrStealController.tsx
+++ b/frontend/src/components/SplitOrStealController.tsx
@@ -235,7 +235,7 @@ const SplitOrStealController: React.FC<SplitOrStealControllerProps> = ({
       <div className="controller-container">
         <div className="current-player-indicator">
           <div className="your-turn">{activePlayer.name}'s Turn</div>
-          <p>Choose your strategy: Split or Steal?</p>
+          <p>Choose your strategy: Cheers Or Tears?</p>
         </div>
 
         <div
@@ -396,7 +396,7 @@ const SplitOrStealController: React.FC<SplitOrStealControllerProps> = ({
 
   return (
     <div className="split-or-steal">
-      <h1>💰 Split or Steal</h1>
+      <h1>💰 Cheers Or Tears</h1>
 
       <button
         className="settings-button"

--- a/frontend/src/components/SplitOrStealDashboard.tsx
+++ b/frontend/src/components/SplitOrStealDashboard.tsx
@@ -415,7 +415,7 @@ const SplitOrStealDashboard: React.FC<SplitOrStealDashboardProps> = ({
           textShadow: "0 0 10px rgba(255, 224, 102, 0.3)",
         }}
       >
-        Players are making their choices: Split or Steal?
+        Players are making their choices: Cheers Or Tears?
       </p>
     </div>
   );
@@ -484,7 +484,7 @@ const SplitOrStealDashboard: React.FC<SplitOrStealDashboardProps> = ({
         {/* Title Section */}
         <div className="reveal-title-section">
           <h1 className="reveal-title">The Reveal</h1>
-          <p className="reveal-subtitle">Did they split or steal?</p>
+          <p className="reveal-subtitle">Did they cheers or cry?</p>
         </div>
 
         {results &&
@@ -1027,7 +1027,7 @@ const SplitOrStealDashboard: React.FC<SplitOrStealDashboardProps> = ({
               textShadow: "0 0 30px rgba(255, 140, 0, 0.3)",
             }}
           >
-            💰 Split or Steal
+            💰 Cheers Or Tears
           </h1>
           <div
             style={{
@@ -1087,7 +1087,7 @@ const SplitOrStealDashboard: React.FC<SplitOrStealDashboardProps> = ({
             textShadow: "0 0 30px rgba(255, 165, 0, 0.5)",
           }}
         >
-          💰 Split or Steal
+          💰 Cheers Or Tears
         </h1>
 
         <button

--- a/frontend/src/components/SplitOrStealSetup.tsx
+++ b/frontend/src/components/SplitOrStealSetup.tsx
@@ -70,7 +70,7 @@ const SplitOrStealSetup: React.FC<SplitOrStealSetupProps> = ({
     return (
       <BlueDotBackground>
         <div style={styles.container}>
-          <h1 style={styles.mainTitle}>💰 Split or Steal</h1>
+          <h1 style={styles.mainTitle}>💰 Cheers Or Tears</h1>
           <div style={styles.card}>
             <h3 style={{ ...styles.subTitle, color: "#4d9eff" }}>
               Waiting for Host
@@ -88,7 +88,7 @@ const SplitOrStealSetup: React.FC<SplitOrStealSetupProps> = ({
   return (
     <BlueDotBackground>
       <div style={styles.container}>
-        <h1 style={styles.mainTitle}>💰 Split or Steal</h1>
+        <h1 style={styles.mainTitle}>💰 Cheers Or Tears</h1>
 
         <div
           style={{

--- a/frontend/src/components/fdfd.tsx
+++ b/frontend/src/components/fdfd.tsx
@@ -180,7 +180,7 @@ const SplitOrStealDashboard: React.FC<SplitOrStealDashboardProps> = ({
       )}
 
       <p style={{ fontSize: "1.2rem", opacity: 0.9 }}>
-        Players are making their choices: Split or Steal?
+        Players are making their choices: Cheers Or Tears?
       </p>
     </div>
   );
@@ -242,7 +242,7 @@ const SplitOrStealDashboard: React.FC<SplitOrStealDashboardProps> = ({
         {/* Title Section */}
         <div className="reveal-title-section">
           <h1 className="reveal-title">The Reveal</h1>
-          <p className="reveal-subtitle">Did they split or steal?</p>
+          <p className="reveal-subtitle">Did they cheers or cry?</p>
         </div>
 
         {results &&
@@ -643,7 +643,7 @@ const SplitOrStealDashboard: React.FC<SplitOrStealDashboardProps> = ({
   if (!isHost) {
     return (
       <div className="split-or-steal">
-        <h1>💰 Split or Steal</h1>
+        <h1>💰 Cheers Or Tears</h1>
         <div className="wait-message">
           <h3>Game in progress...</h3>
           <p>The host is managing the game. Watch the main screen!</p>
@@ -659,7 +659,7 @@ const SplitOrStealDashboard: React.FC<SplitOrStealDashboardProps> = ({
 
   return (
     <div className="split-or-steal">
-      <h1>💰 Split or Steal</h1>
+      <h1>💰 Cheers Or Tears</h1>
 
       <button
         className="settings-button"


### PR DESCRIPTION
## Summary
- rename game text from "Split or Steal" to "Cheers Or Tears" across the frontend components
- update GameLobby game option labels
- adjust dashboard/controller/other UI text accordingly

## Testing
- `CI=true npm test --silent --runInBand` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_688d43a1b61c832cb7c5ae070642889a