### PR TITLE
Add intensity options & timer update to SplitOrSteal

### DIFF
--- a/frontend/src/components/SplitOrStealDashboard.tsx
+++ b/frontend/src/components/SplitOrStealDashboard.tsx
@@ -28,6 +28,7 @@ interface GameState {
   currentPair?: CurrentPair | null;
   results?: Results | null;
   participants?: Participant[];
+  intensity?: string;
 }
 
 interface SplitOrStealDashboardProps {
@@ -61,6 +62,9 @@ const SplitOrStealDashboard: React.FC<SplitOrStealDashboardProps> = ({
   );
   const [newParticipantName, setNewParticipantName] = useState("");
   const [showPostReveal, setShowPostReveal] = useState(false);
+  const [gameIntensity, setGameIntensity] = useState<string>(
+    gameState.intensity || "Chill"
+  );
 
   // Initialize state from gameState
   useEffect(() => {
@@ -70,6 +74,7 @@ const SplitOrStealDashboard: React.FC<SplitOrStealDashboardProps> = ({
       setCurrentPair(gameState.currentPair || null);
       setResults(gameState.results || null);
       setParticipants(gameState.participants || []);
+      setGameIntensity(gameState.intensity || "Chill");
     }
   }, [gameState]);
 
@@ -98,6 +103,10 @@ const SplitOrStealDashboard: React.FC<SplitOrStealDashboardProps> = ({
       if (data.participants) {
         setParticipants(data.participants);
       }
+
+      if (data.intensity) {
+        setGameIntensity(data.intensity);
+      }
     };
 
     socket.on("split-steal-timer", handleTimerUpdate);
@@ -123,19 +132,32 @@ const SplitOrStealDashboard: React.FC<SplitOrStealDashboardProps> = ({
     return `${mins}:${secs.toString().padStart(2, "0")}`;
   };
 
-  const calculateSips = (intensity: string) => {
-    switch (intensity) {
-      case "Mild":
-        return 1;
-      case "Medium":
-        return 2;
-      case "Fyllehund":
-        return 3;
-      case "Grøfta":
-        return 4;
-      default:
-        return 2;
+  const intensityMap: Record<string, { cheersCheers: number; tearsCheers: number; tearsTears: number }> = {
+    Chill: { cheersCheers: 3, tearsCheers: 8, tearsTears: 6 },
+    Medium: { cheersCheers: 4, tearsCheers: 10, tearsTears: 8 },
+    Fyllehund: { cheersCheers: 6, tearsCheers: 15, tearsTears: 12 },
+    Grøfta: { cheersCheers: 9, tearsCheers: 23, tearsTears: 18 },
+  };
+
+  const calculateSips = (
+    playerChoice?: string,
+    opponentChoice?: string
+  ): number => {
+    const values = intensityMap[gameIntensity] || intensityMap.Chill;
+
+    if (playerChoice === "SPLIT" && opponentChoice === "SPLIT") {
+      return values.cheersCheers;
     }
+    if (playerChoice === "STEAL" && opponentChoice === "STEAL") {
+      return values.tearsTears;
+    }
+    if (
+      (playerChoice === "STEAL" && opponentChoice === "SPLIT") ||
+      (playerChoice === "SPLIT" && opponentChoice === "STEAL")
+    ) {
+      return values.tearsCheers;
+    }
+    return 0;
   };
 
   const handleAddParticipant = () => {
@@ -435,8 +457,8 @@ const SplitOrStealDashboard: React.FC<SplitOrStealDashboardProps> = ({
         : undefined;
 
     if (showPostReveal && currentPair) {
-      const player1Sips = calculateSips(currentPair.player1.intensity);
-      const player2Sips = calculateSips(currentPair.player2.intensity);
+      const player1Sips = calculateSips(player1Choice, player2Choice);
+      const player2Sips = calculateSips(player2Choice, player1Choice);
 
       return (
         <div className="reveal-phase">

--- a/frontend/src/components/SplitOrStealSetup.tsx
+++ b/frontend/src/components/SplitOrStealSetup.tsx
@@ -25,7 +25,9 @@ const SplitOrStealSetup: React.FC<SplitOrStealSetupProps> = ({
   isHost,
   socket,
 }) => {
-  const [countdownDuration, setCountdownDuration] = useState<number>(30);
+  const [countdownMinutes, setCountdownMinutes] = useState<number>(0);
+  const [countdownSeconds, setCountdownSeconds] = useState<number>(30);
+  const [intensity, setIntensity] = useState<string>("Chill");
   const [participants, setParticipants] = useState<Participant[]>([]);
   const [newParticipantName, setNewParticipantName] = useState<string>("");
 
@@ -53,8 +55,10 @@ const SplitOrStealSetup: React.FC<SplitOrStealSetupProps> = ({
 
   const handleStartGame = () => {
     if (!socket || !isHost || participants.length < 2) return;
+    const totalSeconds = countdownMinutes * 60 + countdownSeconds;
     socket.emit("split-steal-config", sessionId, {
-      countdownDuration,
+      countdownDuration: totalSeconds,
+      intensity,
       participants,
     });
   };
@@ -101,19 +105,46 @@ const SplitOrStealSetup: React.FC<SplitOrStealSetupProps> = ({
 
           {/* Countdown Duration */}
           <div style={styles.formGroup}>
-            <label style={styles.label}>
-              Countdown Between Duels (10-300s)
-            </label>
-            <input
-              type="number"
-              min="10"
-              max="300"
-              value={countdownDuration}
-              onChange={(e) =>
-                setCountdownDuration(parseInt(e.target.value, 10) || 30)
-              }
+            <label style={styles.label}>Countdown Between Duels</label>
+            <div style={{ display: "flex", gap: "0.5rem" }}>
+              <input
+                type="number"
+                min="0"
+                max="5"
+                value={countdownMinutes}
+                onChange={(e) =>
+                  setCountdownMinutes(Math.max(0, parseInt(e.target.value, 10) || 0))
+                }
+                style={{ ...styles.input, width: "80px" }}
+              />
+              <span style={{ alignSelf: "center" }}>min</span>
+              <input
+                type="number"
+                min="0"
+                max="59"
+                value={countdownSeconds}
+                onChange={(e) =>
+                  setCountdownSeconds(Math.max(0, parseInt(e.target.value, 10) || 0))
+                }
+                style={{ ...styles.input, width: "80px" }}
+              />
+              <span style={{ alignSelf: "center" }}>sec</span>
+            </div>
+          </div>
+
+          {/* Intensity */}
+          <div style={styles.formGroup}>
+            <label style={styles.label}>Intensity</label>
+            <select
+              value={intensity}
+              onChange={(e) => setIntensity(e.target.value)}
               style={styles.input}
-            />
+            >
+              <option value="Chill">Chill</option>
+              <option value="Medium">Medium</option>
+              <option value="Fyllehund">Fyllehund</option>
+              <option value="Grøfta">Grøfta</option>
+            </select>
           </div>
 
           {/* Participants List */}

--- a/server/index.js
+++ b/server/index.js
@@ -2020,6 +2020,7 @@ io.on("connection", (socket) => {
       timeLeft: duration,
       leaderboard: session.gameState.leaderboard,
       participants: session.gameState.participants,
+      intensity: session.gameState.intensity,
     });
 
     // Clear any existing timer
@@ -2082,6 +2083,7 @@ io.on("connection", (socket) => {
       currentPair: pair,
       leaderboard: session.gameState.leaderboard,
       participants: session.gameState.participants,
+      intensity: session.gameState.intensity,
     });
 
     // Clear any existing timer
@@ -2131,6 +2133,7 @@ io.on("connection", (socket) => {
       currentPlayer: session.gameState.currentPlayer,
       leaderboard: session.gameState.leaderboard,
       participants: session.gameState.participants,
+      intensity: session.gameState.intensity,
     });
 
     // Clear any existing timer
@@ -2182,6 +2185,7 @@ io.on("connection", (socket) => {
       results: results,
       leaderboard: session.gameState.leaderboard,
       participants: session.gameState.participants,
+      intensity: session.gameState.intensity,
     });
 
     // Clear any existing timer
@@ -2248,6 +2252,7 @@ io.on("connection", (socket) => {
     session.gameState = {
       phase: "countdown",
       countdownDuration: config.countdownDuration,
+      intensity: config.intensity,
       participants: validParticipants,
       scoreboard: {}, // player_id -> points
       leaderboard: [], // sorted array for display
@@ -2405,6 +2410,7 @@ io.on("connection", (socket) => {
       leaderboard: session.gameState.leaderboard,
       participants: session.gameState.participants,
       currentPlayer: session.gameState.currentPlayer,
+      intensity: session.gameState.intensity,
     });
   });
 
@@ -2458,6 +2464,7 @@ io.on("connection", (socket) => {
         leaderboard: session.gameState.leaderboard,
         participants: session.gameState.participants,
         currentPlayer: session.gameState.currentPlayer,
+        intensity: session.gameState.intensity,
       });
     }
   });


### PR DESCRIPTION
## Summary
- add intensity configuration to SplitOrSteal setup
- allow minutes+seconds input for countdown timer
- persist intensity in server game state and include in state updates
- use intensity values on the dashboard to calculate drink amounts

## Testing
- `npm test --prefix frontend` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_688d4bbbdf4c832ca4a4a3fac412cccf